### PR TITLE
Add parse_duration unit tests

### DIFF
--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,0 +1,29 @@
+from datetime import timedelta
+import pytest
+import sys
+from pathlib import Path
+
+# Ensure the project root is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from modules.utils.time import parse_duration
+
+@pytest.mark.parametrize(
+    "input_str,expected",
+    [
+        ("10s", timedelta(seconds=10)),
+        ("5m", timedelta(minutes=5)),
+        ("2h", timedelta(hours=2)),
+        ("3d", timedelta(days=3)),
+        ("1w", timedelta(weeks=1)),
+        ("2mo", timedelta(days=60)),
+        ("1y", timedelta(days=365)),
+    ],
+)
+def test_parse_duration_valid(input_str, expected):
+    assert parse_duration(input_str) == expected
+
+
+@pytest.mark.parametrize("input_str", ["5x", ""])
+def test_parse_duration_invalid(input_str):
+    assert parse_duration(input_str) is None


### PR DESCRIPTION
## Summary
- test coverage for `modules.utils.time.parse_duration`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e72c1268832dbed1250a096bdc21