### PR TITLE
Refactor action lists

### DIFF
--- a/cogs/banned_words.py
+++ b/cogs/banned_words.py
@@ -11,6 +11,7 @@ from better_profanity import profanity
 from cleantext import clean
 from modules.utils import mysql
 from modules.utils.strike import validate_action_with_duration
+from modules.utils.actions import action_choices, BASIC_ACTIONS
 
 BANNED_ACTION_SETTING = "banned-words-action"
 manager = ActionListManager(BANNED_ACTION_SETTING)
@@ -258,16 +259,7 @@ class BannedWordsCog(commands.Cog):
         action="Action: strike, kick, ban, timeout, delete",
         duration="Only required for timeout (e.g. 10m, 1h, 3d)"
     )
-    @app_commands.choices(
-        action=[
-            app_commands.Choice(name="strike", value="strike"),
-            app_commands.Choice(name="kick", value="kick"),
-            app_commands.Choice(name="ban", value="ban"),
-            app_commands.Choice(name="timeout", value="timeout"),
-            app_commands.Choice(name="delete", value="delete"),
-            app_commands.Choice(name="give_role", value="give_role"),
-            app_commands.Choice(name="take_role", value="take_role")
-        ])
+    @app_commands.choices(action=action_choices())
     async def add_banned_action(
         self,
         interaction: Interaction,
@@ -278,7 +270,7 @@ class BannedWordsCog(commands.Cog):
             interaction=interaction,
             action=action,
             duration=duration,
-            valid_actions=["strike", "kick", "ban", "timeout", "delete"]
+            valid_actions=BASIC_ACTIONS,
         )
         if action_str is None:
             return
@@ -288,16 +280,7 @@ class BannedWordsCog(commands.Cog):
 
     @bannedwords_group.command(name="remove_action", description="Remove a specific action from the list of punishments for banned words.")
     @app_commands.describe(action="Exact action string to remove (e.g. timeout, delete)")
-    @app_commands.choices(
-        action=[
-            app_commands.Choice(name="strike", value="strike"),
-            app_commands.Choice(name="kick", value="kick"),
-            app_commands.Choice(name="ban", value="ban"),
-            app_commands.Choice(name="timeout", value="timeout"),
-            app_commands.Choice(name="delete", value="delete"),
-            app_commands.Choice(name="give_role", value="give_role"),
-            app_commands.Choice(name="take_role", value="take_role")
-        ])
+    @app_commands.choices(action=action_choices())
     async def remove_banned_action(self, interaction: Interaction, action: str):
         msg = await manager.remove_action(interaction.guild.id, action)
         await interaction.response.send_message(msg, ephemeral=True)

--- a/cogs/nsfw.py
+++ b/cogs/nsfw.py
@@ -4,6 +4,7 @@ from discord import app_commands, Interaction
 
 from modules.utils.action_manager import ActionListManager
 from modules.utils.strike import validate_action_with_duration
+from modules.utils.actions import action_choices, BASIC_ACTIONS
 
 NSFW_ACTION_SETTING = "nsfw-detection-action"
 manager = ActionListManager(NSFW_ACTION_SETTING)
@@ -24,16 +25,7 @@ class NSFWCog(commands.Cog):
         action="Action: strike, kick, ban, timeout, delete",
         duration="Only required for timeout (e.g. 10m, 1h, 3d)"
     )
-    @app_commands.choices(
-        action=[
-            app_commands.Choice(name="strike", value="strike"),
-            app_commands.Choice(name="kick", value="kick"),
-            app_commands.Choice(name="ban", value="ban"),
-            app_commands.Choice(name="timeout", value="timeout"),
-            app_commands.Choice(name="delete", value="delete"),
-            app_commands.Choice(name="give_role", value="give_role"),
-            app_commands.Choice(name="take_role", value="take_role")
-        ])
+    @app_commands.choices(action=action_choices())
     async def add_nsfw_action(
         self,
         interaction: Interaction,
@@ -46,7 +38,7 @@ class NSFWCog(commands.Cog):
             interaction=interaction,
             action=action,
             duration=duration,
-            valid_actions=["strike", "kick", "ban", "timeout", "delete"]
+            valid_actions=BASIC_ACTIONS,
         )
         if action_str is None:
             return
@@ -56,16 +48,7 @@ class NSFWCog(commands.Cog):
 
     @nsfw_group.command(name="remove_action", description="Remove an action from the NSFW punishment list.")
     @app_commands.describe(action="Exact action string to remove (e.g. timeout, delete)")
-    @app_commands.choices(
-        action=[
-            app_commands.Choice(name="strike", value="strike"),
-            app_commands.Choice(name="kick", value="kick"),
-            app_commands.Choice(name="ban", value="ban"),
-            app_commands.Choice(name="timeout", value="timeout"),
-            app_commands.Choice(name="delete", value="delete"),
-            app_commands.Choice(name="give_role", value="give_role"),
-            app_commands.Choice(name="take_role", value="take_role")
-        ])
+    @app_commands.choices(action=action_choices())
     async def remove_nsfw_action(self, interaction: Interaction, action: str):
         gid = interaction.guild.id
 

--- a/cogs/scam_detection.py
+++ b/cogs/scam_detection.py
@@ -8,6 +8,7 @@ from modules.utils.mysql import execute_query, get_settings, update_settings
 from modules.moderation import strike
 from urlextract import URLExtract
 from modules.utils.strike import validate_action_with_duration
+from modules.utils.actions import action_choices, ALL_ACTIONS
 from transformers import pipeline
 from cogs.banned_words import normalize_text
 import requests
@@ -346,16 +347,7 @@ class ScamDetectionCog(commands.Cog):
         action="Action: strike, kick, ban, timeout, delete",
         duration="Only required for timeout (e.g. 10m, 1h, 3d)"
     )
-    @app_commands.choices(
-        action=[
-            app_commands.Choice(name="strike", value="strike"),
-            app_commands.Choice(name="kick", value="kick"),
-            app_commands.Choice(name="ban", value="ban"),
-            app_commands.Choice(name="timeout", value="timeout"),
-            app_commands.Choice(name="delete", value="delete"),
-            app_commands.Choice(name="give_role", value="give_role"),
-            app_commands.Choice(name="take_role", value="take_role")
-        ])
+    @app_commands.choices(action=action_choices())
     async def scam_add_action(
         self,
         interaction: Interaction,
@@ -368,7 +360,7 @@ class ScamDetectionCog(commands.Cog):
             interaction=interaction,
             action=action,
             duration=duration,
-            valid_actions=["strike", "kick", "ban", "timeout", "delete", "give_role", "take_role"]
+            valid_actions=ALL_ACTIONS,
         )
         if action_str is None:
             return

--- a/modules/utils/actions.py
+++ b/modules/utils/actions.py
@@ -1,0 +1,11 @@
+from discord import app_commands
+
+BASIC_ACTIONS = ["strike", "kick", "ban", "timeout", "delete"]
+ROLE_ACTIONS = ["give_role", "take_role"]
+ALL_ACTIONS = BASIC_ACTIONS + ROLE_ACTIONS
+
+
+def action_choices(include_role_actions: bool = True) -> list[app_commands.Choice[str]]:
+    """Return `app_commands.Choice` list for moderation actions."""
+    actions = ALL_ACTIONS if include_role_actions else BASIC_ACTIONS
+    return [app_commands.Choice(name=a, value=a) for a in actions]


### PR DESCRIPTION
## Summary
- centralize moderation actions in a single utility
- simplify command choice lists in NSFW, banned words, and scam detection cogs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d10e68914832d91389ca222b8eff9