### PR TITLE
Simplify pycache ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,29 +1,7 @@
 /.env
 test.py
-modules/config/__pycache__/settings_schema.cpython-310.pyc
-modules/utils/__pycache__/api.cpython-310.pyc
-modules/utils/__pycache__/logging.cpython-310.pyc
-modules/utils/__pycache__/mysql.cpython-310.pyc
-modules/utils/__pycache__/time.cpython-310.pyc
-modules/utils/__pycache__/user_utils.cpython-310.pyc
-modules/variables/__pycache__/TimeString.cpython-310.pyc
-cogs/__pycache__/banned_words.cpython-310.pyc
-cogs/__pycache__/scam_detection.cpython-310.pyc
-modules/moderation/__pycache__/strike.cpython-310.pyc
-modules/utils/__pycache__/discord_utils.cpython-310.pyc
-modules/utils/__pycache__/strike.cpython-310.pyc
-cogs/__pycache__/.moderation.cpython-310.pyc.~5e57
-cogs/__pycache__/aggregated_moderation.cpython-310.pyc
-cogs/__pycache__/api_pool.cpython-310.pyc
-cogs/__pycache__/moderation.cpython-310 (case clash from 2025-02-21 012149).pyc
-cogs/__pycache__/Moderation.cpython-310.pyc
-cogs/__pycache__/monitoring.cpython-310.pyc
-cogs/__pycache__/scam_detection.cpython-310 (conflicted copy 2025-06-03 132323).pyc
-cogs/__pycache__/settings.cpython-310.pyc
-modules/moderation/__pycache__/warn.cpython-310.pyc
-tests/__pycache__/test_time.cpython-310-pytest-8.4.0.pyc
 test/model.py
 test/announce.py
-__pycache__/bot.cpython-310.pyc
-modules/post_stats/__pycache__/topgg_poster.cpython-310.pyc
 test/url.py
+__pycache__/
+*.pyc


### PR DESCRIPTION
## Summary
- ignore `__pycache__` directories and compiled Python files
- remove long list of compiled Python files from `.gitignore`

## Testing
- `pytest -q`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d2173280c832d84ebc6c2cf2663e7