### PR TITLE
Support multiple strike actions per strike count

### DIFF
--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -297,10 +297,9 @@ class Settings(commands.Cog):
                 await interaction.followup.send(
                     f"`{name}` is currently set to {channel_mention}.", ephemeral=True
                 )
-            elif type == dict[int, tuple[str, str]]:
-                # Convert the dictionary to a string representation
+            elif type == dict[str, list[str]]:
                 strike_actions = ", ".join(
-                    [f"{k}: {v[0]} {v[1] or ''}" for k, v in current_value.items()]
+                    [f"{k}: {', '.join(v)}" for k, v in current_value.items()]
                 )
                 await interaction.followup.send(
                     f"`{name}` is currently set to `{strike_actions}`.", ephemeral=True

--- a/modules/config/settings_schema.py
+++ b/modules/config/settings_schema.py
@@ -87,12 +87,12 @@ SETTINGS_SCHEMA = {
     "strike-actions": Setting(
         name="strike-actions",
         description="Actions to take for each strike level.",
-        setting_type=dict[str, tuple[str, str]],
+        setting_type=dict[str, list[str]],
         hidden=True,
         default={
-            "1": ("timeout", "1d"),
-            "2": ("timeout", "7d"),
-            "3": ("ban", "-1"), 
+            "1": ["timeout:1d"],
+            "2": ["timeout:7d"],
+            "3": ["ban"],
         },
     ),
     "strike-expiry": Setting(

--- a/modules/utils/strike_action_manager.py
+++ b/modules/utils/strike_action_manager.py
@@ -1,0 +1,35 @@
+from modules.utils.mysql import get_settings, update_settings
+
+class StrikeActionManager:
+    def __init__(self, setting_key: str = "strike-actions"):
+        self.setting_key = setting_key
+
+    async def add_action(self, guild_id: int, strike: int | str, new_action: str) -> str:
+        actions_map = await get_settings(guild_id, self.setting_key) or {}
+        strike = str(strike)
+        current = actions_map.get(strike, [])
+        normalized = [a.split(":")[0] for a in current]
+        if new_action.split(":")[0] in normalized:
+            return f"`{new_action}` is already set for `{strike}` strike(s)."
+        current.append(new_action)
+        actions_map[strike] = current
+        await update_settings(guild_id, self.setting_key, actions_map)
+        return f"Added `{new_action}` for `{strike}` strike(s)."
+
+    async def remove_action(self, guild_id: int, strike: int | str, action: str) -> str:
+        actions_map = await get_settings(guild_id, self.setting_key) or {}
+        strike = str(strike)
+        current = actions_map.get(strike, [])
+        normalized = [a.split(":")[0] for a in current]
+        if action not in normalized:
+            return f"`{action}` is not set for `{strike}` strike(s)."
+        updated = [a for a in current if a.split(":")[0] != action]
+        if updated:
+            actions_map[strike] = updated
+        else:
+            actions_map.pop(strike, None)
+        await update_settings(guild_id, self.setting_key, actions_map)
+        return f"Removed `{action}` from `{strike}` strike(s)."
+
+    async def view_actions(self, guild_id: int) -> dict:
+        return await get_settings(guild_id, self.setting_key) or {}


### PR DESCRIPTION
## Summary
- allow multiple actions to be configured for each strike level
- enable removing actions individually from a strike count
- update strike logic to execute lists of actions
- add new `StrikeActionManager` utility
- adjust settings schema and retrieval for the new structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685112c8e380832d911fa9a63196e887