### PR TITLE
Support multiple actions per strike

### DIFF
--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -297,10 +297,9 @@ class Settings(commands.Cog):
                 await interaction.followup.send(
                     f"`{name}` is currently set to {channel_mention}.", ephemeral=True
                 )
-            elif type == dict[int, tuple[str, str]]:
-                # Convert the dictionary to a string representation
+            elif type == dict[str, list[str]]:
                 strike_actions = ", ".join(
-                    [f"{k}: {v[0]} {v[1] or ''}" for k, v in current_value.items()]
+                    [f"{k}: {', '.join(v)}" for k, v in current_value.items()]
                 )
                 await interaction.followup.send(
                     f"`{name}` is currently set to `{strike_actions}`.", ephemeral=True

--- a/modules/config/settings_schema.py
+++ b/modules/config/settings_schema.py
@@ -87,12 +87,12 @@ SETTINGS_SCHEMA = {
     "strike-actions": Setting(
         name="strike-actions",
         description="Actions to take for each strike level.",
-        setting_type=dict[str, tuple[str, str]],
+        setting_type=dict[str, list[str]],
         hidden=True,
         default={
-            "1": ("timeout", "1d"),
-            "2": ("timeout", "7d"),
-            "3": ("ban", "-1"), 
+            "1": ["timeout:1d"],
+            "2": ["timeout:7d"],
+            "3": ["ban"],
         },
     ),
     "strike-expiry": Setting(

--- a/modules/utils/mysql.py
+++ b/modules/utils/mysql.py
@@ -258,6 +258,19 @@ async def get_settings(guild_id: int, settings_key: str | None = None):
             # Strip out "none" from migrated data
             value = [v for v in value if v != "none"]
 
+        if settings_key == "strike-actions":
+            migrated = {}
+            if isinstance(value, dict):
+                for k, v in value.items():
+                    if isinstance(v, list):
+                        migrated[k] = v
+                    elif isinstance(v, tuple):
+                        a, d = v
+                        migrated[k] = [f"{a}:{d}" if d else a]
+                    else:
+                        migrated[k] = [str(v)]
+                value = migrated
+
         return value
 
     # Handle full settings dict return
@@ -280,6 +293,17 @@ async def update_settings(guild_id: int, settings_key: str, settings_value):
     if settings_value is None:
         changed = settings.pop(settings_key, None) is not None
     else:
+        if settings_key == "strike-actions" and isinstance(settings_value, dict):
+            converted = {}
+            for k, v in settings_value.items():
+                if isinstance(v, list):
+                    converted[k] = v
+                elif isinstance(v, tuple):
+                    a, d = v
+                    converted[k] = [f"{a}:{d}" if d else a]
+                else:
+                    converted[k] = [str(v)]
+            settings_value = converted
         if encrypt_current:
             settings_value = fernet.encrypt(settings_value.encode()).decode()
         settings[settings_key] = settings_value


### PR DESCRIPTION
## Summary
- store strike actions as a list so multiple actions can be triggered
- migrate old settings when loading or saving
- update strike workflow to handle multiple actions
- show lists of actions in settings output
- add `/strikes add_action`, `/strikes remove_action`, `/strikes view_actions`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685116af1414832d8efbacb97d47d4ff