### PR TITLE
Batch AI moderation processing

### DIFF
--- a/modules/config/settings_schema.py
+++ b/modules/config/settings_schema.py
@@ -219,9 +219,15 @@ SETTINGS_SCHEMA = {
             "gpt-4.1",
             "gpt-4.1-mini",
             "gpt-4.1-nano",
-            "gpt-4o",           
+            "gpt-4o",
             "gpt-4o-mini",
         ]
+    ),
+    "aimod-check-interval": Setting(
+        name="aimod-check-interval",
+        description="How often to run the AI moderation batch process.",
+        setting_type=TimeString,
+        default=TimeString("4h"),
     ),
     "contextual-ai": Setting(
         name="contextual-ai",


### PR DESCRIPTION
## Summary
- add `aimod-check-interval` setting to configure AI moderation batch interval
- queue messages and process them in batches
- include task loop that processes each guild queue based on configured interval

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68527c0c8c08832d9d22478d552e5d8b