### PR TITLE
Add configurable NSFW categories

### DIFF
--- a/modules/config/settings_schema.py
+++ b/modules/config/settings_schema.py
@@ -49,6 +49,20 @@ SETTINGS_SCHEMA = {
         hidden=True,
         choices=["strike", "kick", "ban", "timeout", "delete"]
     ),
+    "nsfw-detection-categories": Setting(
+        name="nsfw-detection-categories",
+        description="Categories considered NSFW for detection.",
+        setting_type=list[str],
+        default=[
+            "violence/graphic",
+            "violence",
+            "sexual",
+            "self-harm/instructions",
+            "self-harm/intent",
+            "self-harm",
+        ],
+        hidden=True,
+    ),
     "banned-words-action": Setting(
         name="banned-words-action",
         description="Action to take when a user posts a banned word.",

--- a/modules/utils/list_manager.py
+++ b/modules/utils/list_manager.py
@@ -1,0 +1,35 @@
+from modules.utils.mysql import get_settings, update_settings
+from discord import app_commands, Interaction
+
+class ListManager:
+    def __init__(self, setting_key: str):
+        self.setting_key = setting_key
+
+    async def add(self, guild_id: int, item: str) -> str:
+        items = await get_settings(guild_id, self.setting_key) or []
+        if not isinstance(items, list):
+            items = [items]
+        if item in items:
+            return f"`{item}` is already in the list."
+        items.append(item)
+        await update_settings(guild_id, self.setting_key, items)
+        return f"Added `{item}` to the list."
+
+    async def remove(self, guild_id: int, item: str) -> str:
+        items = await get_settings(guild_id, self.setting_key) or []
+        if item not in items:
+            return f"`{item}` is not in the list."
+        items.remove(item)
+        await update_settings(guild_id, self.setting_key, items)
+        return f"Removed `{item}` from the list."
+
+    async def view(self, guild_id: int) -> list[str]:
+        items = await get_settings(guild_id, self.setting_key) or []
+        return items if isinstance(items, list) else [items]
+
+    async def autocomplete(self, interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:
+        items = await self.view(interaction.guild.id)
+        return [
+            app_commands.Choice(name=item, value=item)
+            for item in items if current.lower() in item.lower()
+        ][:25]


### PR DESCRIPTION
## Summary
- let admins manage NSFW categories via `/nsfw` commands
- store categories in `nsfw-detection-categories` setting
- use new setting when checking content
- add generic `ListManager` helper
- respect NSFW category settings when matching images by similarity

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68622e75de90832d98fa3649f47e7deb