### PR TITLE
Improve shard standby readiness

### DIFF
--- a/modules/utils/mysql/__init__.py
+++ b/modules/utils/mysql/__init__.py
@@ -23,6 +23,7 @@ from .shards import (
     ShardClaimError,
     claim_shard,
     ensure_shard_records,
+    recover_stuck_shards,
     release_shard,
     update_shard_status,
 )
@@ -54,6 +55,7 @@ __all__ = [
     "ShardClaimError",
     "claim_shard",
     "ensure_shard_records",
+    "recover_stuck_shards",
     "release_shard",
     "update_shard_status",
 ]


### PR DESCRIPTION
## Summary
- allow the bot process to enter a hot-standby login flow that keeps extensions loaded while it polls for shard availability
- make ModeratorBot support deferred shard assignment so standby instances can connect immediately after a claim
- add a MySQL helper that force releases stale shard rows to guarantee failover even after abrupt crashes

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cf721ff6e8832da9054d748b4d8691