### PR TITLE
Tighten shard standby failover responsiveness

### DIFF
--- a/modules/core/config.py
+++ b/modules/core/config.py
@@ -37,6 +37,7 @@ class ShardConfig:
     preferred_shard: int | None
     stale_seconds: int
     heartbeat_seconds: int
+    instance_heartbeat_seconds: int
     instance_id: str
     standby_when_full: bool
     standby_poll_seconds: int
@@ -94,6 +95,12 @@ def load_runtime_config() -> RuntimeConfig:
         minimum=15,
         name="MODBOT_SHARD_HEARTBEAT_SECONDS",
     )
+    instance_heartbeat_seconds = _parse_int(
+        os.getenv("MODBOT_INSTANCE_HEARTBEAT_SECONDS"),
+        default=3,
+        minimum=2,
+        name="MODBOT_INSTANCE_HEARTBEAT_SECONDS",
+    )
     instance_id = (
         os.getenv("MODBOT_INSTANCE_ID")
         or os.getenv("INSTANCE_ID")
@@ -116,6 +123,7 @@ def load_runtime_config() -> RuntimeConfig:
         preferred_shard=preferred_shard,
         stale_seconds=stale_seconds,
         heartbeat_seconds=heartbeat_seconds,
+        instance_heartbeat_seconds=instance_heartbeat_seconds,
         instance_id=instance_id,
         standby_when_full=standby_when_full,
         standby_poll_seconds=standby_poll_seconds,

--- a/modules/utils/mysql/__init__.py
+++ b/modules/utils/mysql/__init__.py
@@ -17,6 +17,10 @@ from .premium import (
     remove_guild,
     resolve_guild_plan,
 )
+from .instances import (
+    clear_instance_heartbeat,
+    update_instance_heartbeat,
+)
 
 from .shards import (
     ShardAssignment,
@@ -51,6 +55,8 @@ __all__ = [
     "resolve_guild_plan",
     "add_guild",
     "remove_guild",
+    "update_instance_heartbeat",
+    "clear_instance_heartbeat",
     "ShardAssignment",
     "ShardClaimError",
     "claim_shard",

--- a/modules/utils/mysql/connection.py
+++ b/modules/utils/mysql/connection.py
@@ -161,6 +161,16 @@ async def _ensure_database_exists() -> None:
             )
             await cur.execute(
                 """
+                CREATE TABLE IF NOT EXISTS bot_instances (
+                    instance_id VARCHAR(128) PRIMARY KEY,
+                    last_seen DATETIME NOT NULL,
+                    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                    INDEX idx_last_seen (last_seen)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+                """
+            )
+            await cur.execute(
+                """
                 CREATE TABLE IF NOT EXISTS guilds (
                     guild_id BIGINT PRIMARY KEY,
                     name VARCHAR(255) NOT NULL,

--- a/modules/utils/mysql/instances.py
+++ b/modules/utils/mysql/instances.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from .connection import get_pool
+
+
+async def update_instance_heartbeat(instance_id: str) -> None:
+    """Mark an instance as alive by updating its heartbeat timestamp."""
+
+    if not instance_id:
+        return
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                """
+                INSERT INTO bot_instances (instance_id, last_seen)
+                VALUES (%s, UTC_TIMESTAMP())
+                ON DUPLICATE KEY UPDATE last_seen = VALUES(last_seen)
+                """,
+                (instance_id,),
+            )
+            await conn.commit()
+
+
+async def clear_instance_heartbeat(instance_id: str) -> None:
+    """Remove any heartbeat record for the given instance."""
+
+    if not instance_id:
+        return
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "DELETE FROM bot_instances WHERE instance_id = %s",
+                (instance_id,),
+            )
+            await conn.commit()
+
+


### PR DESCRIPTION
## Summary
- refresh the standby claim loop so it keeps the instance heartbeat current, reclaims unresponsive owners immediately, and requests shards with fast instance failover thresholds
- lower the default instance heartbeat interval to 3s so stale instances are detected quickly and prune-only utilities stay minimal
- fold shard recovery into unified SQL that also releases rows held by instances whose heartbeat lapsed

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cf9088a4d4832d84998a51025d1f29