### PR TITLE
Add captcha verification violation lookup toggle

### DIFF
--- a/modules/captcha/processor.py
+++ b/modules/captcha/processor.py
@@ -55,6 +55,7 @@ class CaptchaCallbackProcessor:
                 "captcha-failure-actions",
                 "captcha-max-attempts",
                 "captcha-log-channel",
+                "captcha-user-lookup",
             ],
         )
 
@@ -191,6 +192,11 @@ class CaptchaCallbackProcessor:
             colour=discord.Colour.green(),
         )
 
+        if settings.get("captcha-user-lookup"):
+            lookup_text = await _fetch_violation_lookup(member.id)
+            if lookup_text:
+                embed.add_field(name="Violation Lookup", value=lookup_text, inline=False)
+
         if actions:
             embed.add_field(
                 name="Actions Applied",
@@ -269,6 +275,12 @@ class CaptchaCallbackProcessor:
             ),
             colour=discord.Colour.red(),
         )
+
+        if settings.get("captcha-user-lookup"):
+            lookup_text = await _fetch_violation_lookup(member.id)
+            if lookup_text:
+                embed.add_field(name="Violation Lookup", value=lookup_text, inline=False)
+
         if applied_actions:
             embed.add_field(
                 name="Actions Applied",
@@ -428,6 +440,42 @@ def _coerce_int(value: Any) -> int | None:
         return int(text)
     except (TypeError, ValueError):
         return None
+
+
+async def _fetch_violation_lookup(user_id: int) -> str | None:
+    try:
+        stats = await mysql.get_violations_stats(user_id)
+    except Exception:
+        _logger.exception("Failed to fetch violation stats for user %s", user_id)
+        return None
+
+    return _format_violation_lookup(stats)
+
+
+def _format_violation_lookup(stats: Mapping[str, Any] | None) -> str:
+    if not stats:
+        return "No past violations found."
+
+    try:
+        total = int(stats.get("total_strikes", 0))
+    except (TypeError, ValueError):
+        total = 0
+    try:
+        guild_count = int(stats.get("guild_count", 0))
+    except (TypeError, ValueError):
+        guild_count = 0
+
+    if total <= 0:
+        return "No past violations found."
+
+    strike_word = "strike" if total == 1 else "strikes"
+    guild_word = "server" if guild_count == 1 else "servers"
+
+    if guild_count <= 0:
+        return f"{total} {strike_word} on record."
+
+    return f"{total} {strike_word} across {guild_count} {guild_word}."
+
 
 def _extract_metadata_int(metadata: Mapping[str, Any], *keys: str) -> int | None:
     for key in keys:

--- a/modules/config/settings_schema.py
+++ b/modules/config/settings_schema.py
@@ -501,6 +501,14 @@ SETTINGS_SCHEMA = {
         default=["kick"],
         required_plans=PLAN_PRO,
     ),
+    "captcha-user-lookup": Setting(
+        name="captcha-user-lookup",
+        description="Check users against known violations during captcha verification.",
+        setting_type=bool,
+        default=False,
+        required_plans=PLAN_PRO,
+        choices=["true", "false"],
+    ),
 }
 
 

--- a/modules/utils/mysql/__init__.py
+++ b/modules/utils/mysql/__init__.py
@@ -7,7 +7,7 @@ from .connection import (
     initialise_and_get_pool,
 )
 from .settings import get_settings, update_settings
-from .strikes import cleanup_expired_strikes, get_strike_count, get_strikes
+from .strikes import cleanup_expired_strikes, get_strike_count, get_strikes, get_violations_stats
 from .usage import add_aimod_usage, add_vcmod_usage, get_aimod_usage, get_vcmod_usage
 from .cleanup import cleanup_orphaned_guilds
 from .premium import (
@@ -43,6 +43,7 @@ __all__ = [
     "get_strike_count",
     "get_strikes",
     "cleanup_expired_strikes",
+    "get_violations_stats",
     "get_settings",
     "update_settings",
     "get_aimod_usage",


### PR DESCRIPTION
## Summary
- add a premium captcha setting that toggles violation lookups during verification
- expose the strike violation lookup helper and surface the results in captcha logs

## Testing
- pytest

------