### PR TITLE
Handle Redis connection failures for captcha stream

### DIFF
--- a/modules/captcha/config.py
+++ b/modules/captcha/config.py
@@ -75,7 +75,7 @@ def _resolve_shared_secret() -> bytes | None:
 
 
 def _resolve_redis_url() -> str | None:
-    url = os.getenv("REDIS_URL")
+    url = os.getenv("CAPTCHA_REDIS_URL") or os.getenv("REDIS_URL")
     if not url:
         return None
 


### PR DESCRIPTION
## Summary
- handle Redis connection errors gracefully when starting the captcha stream listener
- support configuring the captcha listener via the `CAPTCHA_REDIS_URL` environment variable
- add a regression test ensuring the listener disables itself when Redis is unreachable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf9d3f5c98832d800638210ec80cf2