### PR TITLE
Implement captcha embed delivery flow

### DIFF
--- a/cogs/captcha.py
+++ b/cogs/captcha.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from datetime import timedelta
 from typing import Optional
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import discord
+from discord import app_commands, Interaction
 from discord.ext import commands
 from discord.utils import utcnow
 
@@ -19,15 +21,24 @@ from modules.captcha.client import (
     CaptchaApiClient,
     CaptchaApiError,
     CaptchaNotAvailableError,
+    CaptchaGuildConfig,
     CaptchaStartResponse,
 )
 from modules.captcha.sessions import CaptchaSession, CaptchaSessionStore
 
 _DEFAULT_API_BASE = "https://modbot.neomechanical.com/api/captcha"
+_DEFAULT_PUBLIC_VERIFY_URL = "https://modbot.neomechanical.com/captcha"
 _logger = logging.getLogger(__name__)
 
 class CaptchaCog(commands.Cog):
     """Captcha verification flow for new guild members."""
+
+    captcha_group = app_commands.Group(
+        name="captcha",
+        description="Manage captcha verification.",
+        guild_only=True,
+        default_permissions=discord.Permissions(manage_guild=True),
+    )
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot
@@ -36,10 +47,49 @@ class CaptchaCog(commands.Cog):
         self._api_client = CaptchaApiClient(self._api_base, os.getenv("CAPTCHA_API_TOKEN"))
         self._stream_config = CaptchaStreamConfig.from_env()
         self._stream_listener = CaptchaStreamListener(bot, self._stream_config, self._session_store)
+        self._public_verify_url = _resolve_public_verify_url()
+        self._settings_listener_registered = False
+        self._embed_sync_task: asyncio.Task[None] | None = None
+        self._config_cache: dict[int, CaptchaGuildConfig] = {}
+        self._config_cache_expiry: dict[int, float] = {}
+        self._config_cache_ttl = 300.0
 
         if not self._api_client.is_configured:
             _logger.warning(
                 "CAPTCHA_API_TOKEN or API base URL missing; captcha verification will be disabled."
+            )
+
+    @captcha_group.command(name="sync", description="Resend the captcha verification embed.")
+    async def sync_embed_command(self, interaction: Interaction) -> None:
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "This command can only be used in a server.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True)
+
+        try:
+            updated = await self._sync_guild_embed(interaction.guild, force=True)
+        except Exception:
+            _logger.exception(
+                "Failed to synchronise captcha embed for guild %s via command", interaction.guild.id
+            )
+            await interaction.followup.send(
+                "An unexpected error occurred while updating the captcha embed.",
+                ephemeral=True,
+            )
+            return
+
+        if updated:
+            await interaction.followup.send(
+                "Captcha verification embed has been updated.",
+                ephemeral=True,
+            )
+        else:
+            await interaction.followup.send(
+                "Captcha embed delivery is not configured for this server.",
+                ephemeral=True,
             )
 
     async def cog_load(self) -> None:
@@ -53,9 +103,26 @@ class CaptchaCog(commands.Cog):
         else:
             print("[CAPTCHA] Captcha Redis stream listener disabled; callbacks will not be processed.")
 
+        if not self._settings_listener_registered:
+            mysql.add_settings_listener(self._handle_setting_update)
+            self._settings_listener_registered = True
+
+        if self._embed_sync_task is None:
+            self._embed_sync_task = asyncio.create_task(self._initial_sync_embeds())
+
     async def cog_unload(self) -> None:
         await self._stream_listener.stop()
         await self._api_client.close()
+        if self._settings_listener_registered:
+            mysql.remove_settings_listener(self._handle_setting_update)
+            self._settings_listener_registered = False
+        if self._embed_sync_task is not None:
+            self._embed_sync_task.cancel()
+            try:
+                await self._embed_sync_task
+            except asyncio.CancelledError:
+                pass
+            self._embed_sync_task = None
 
     @commands.Cog.listener()
     async def on_member_join(self, member: discord.Member) -> None:
@@ -69,6 +136,8 @@ class CaptchaCog(commands.Cog):
                 "captcha-grace-period",
                 "captcha-max-attempts",
                 "pre-captcha-roles",
+                "captcha-delivery-method",
+                "captcha-embed-channel-id",
             ],
         )
 
@@ -101,13 +170,50 @@ class CaptchaCog(commands.Cog):
                     "Missing permissions to assign pre-captcha roles in guild %s",
                     member.guild.id,
                 )
-            except discord.HTTPException:
-                _logger.warning(
-                    "Failed to assign pre-captcha roles in guild %s for user %s",
-                    member.guild.id,
-                    member.id,
+        except discord.HTTPException:
+            _logger.warning(
+                "Failed to assign pre-captcha roles in guild %s for user %s",
+                member.guild.id,
+                member.id,
+            )
+
+        delivery_method = str(settings.get("captcha-delivery-method") or "dm").lower()
+        embed_channel_id = self._coerce_positive_int(settings.get("captcha-embed-channel-id"))
+        grace_setting = self._coerce_grace_period(settings.get("captcha-grace-period"))
+        grace_delta = parse_duration(grace_setting) if grace_setting else None
+        if grace_delta is None:
+            grace_delta = timedelta(minutes=10)
+        grace_display = grace_setting or self._format_duration(grace_delta)
+        max_attempts = self._coerce_positive_int(settings.get("captcha-max-attempts"))
+
+        if delivery_method == "embed" and embed_channel_id:
+            expires_at = utcnow() + grace_delta
+            session = CaptchaSession(
+                guild_id=member.guild.id,
+                user_id=member.id,
+                token=None,
+                expires_at=expires_at,
+                delivery_method="embed",
+            )
+            await self._session_store.put(session)
+
+            channel = member.guild.get_channel(embed_channel_id)
+            if isinstance(channel, discord.TextChannel):
+                await self._sync_guild_embed(member.guild)
+                await self._notify_member_embed(
+                    member,
+                    channel,
+                    grace_display,
+                    max_attempts,
                 )
-        
+                return
+            else:
+                _logger.warning(
+                    "Captcha embed channel %s not found in guild %s; falling back to DMs",
+                    embed_channel_id,
+                    member.guild.id,
+                )
+
         try:
             start_response = await self._api_client.start_session(
                 member.guild.id,
@@ -142,14 +248,15 @@ class CaptchaCog(commands.Cog):
             token=start_response.token,
             expires_at=start_response.expires_at,
             state=start_response.state,
+            delivery_method="dm",
         )
         await self._session_store.put(session)
 
         await self._notify_member(
             member,
             start_response,
-            grace_period=self._coerce_grace_period(settings.get("captcha-grace-period")),
-            max_attempts=self._coerce_positive_int(settings.get("captcha-max-attempts")),
+            grace_period=grace_setting,
+            max_attempts=max_attempts,
         )
 
     @commands.Cog.listener()
@@ -299,6 +406,273 @@ class CaptchaCog(commands.Cog):
             description += f" You have **{max_attempts}** {attempt_label}."
         return description
 
+    def _build_public_verification_url(self, guild_id: int) -> str:
+        base = self._public_verify_url or _DEFAULT_PUBLIC_VERIFY_URL
+        parts = urlsplit(base)
+        query = dict(parse_qsl(parts.query, keep_blank_values=True))
+        query["guildId"] = str(guild_id)
+        new_query = urlencode(query)
+        rebuilt = parts._replace(query=new_query)
+        return urlunsplit(rebuilt)
+
+    async def _initial_sync_embeds(self) -> None:
+        await self.bot.wait_until_ready()
+        for guild in list(self.bot.guilds):
+            try:
+                await self._sync_guild_embed(guild)
+            except Exception:  # pragma: no cover - defensive logging
+                _logger.exception(
+                    "Failed to synchronise captcha embed for guild %s", guild.id
+                )
+
+    async def _handle_setting_update(self, guild_id: int, key: str, value: object) -> None:
+        if key not in {
+            "captcha-delivery-method",
+            "captcha-embed-channel-id",
+            "captcha-verification-enabled",
+        }:
+            return
+
+        try:
+            resolved_id = int(guild_id)
+        except (TypeError, ValueError):
+            return
+
+        guild = self.bot.get_guild(resolved_id)
+        if guild is None:
+            return
+
+        try:
+            await self._sync_guild_embed(guild, force=True)
+        except Exception:  # pragma: no cover - defensive logging
+            _logger.exception("Failed to update captcha embed for guild %s", resolved_id)
+
+    async def _sync_guild_embed(
+        self,
+        guild: discord.Guild,
+        *,
+        force: bool = False,
+    ) -> bool:
+        settings = await mysql.get_settings(
+            guild.id,
+            [
+                "captcha-verification-enabled",
+                "captcha-delivery-method",
+                "captcha-embed-channel-id",
+            ],
+        )
+
+        enabled = bool(settings.get("captcha-verification-enabled"))
+        delivery_method = str(settings.get("captcha-delivery-method") or "dm").lower()
+        channel_id = self._coerce_positive_int(settings.get("captcha-embed-channel-id"))
+
+        if not enabled or delivery_method != "embed" or not channel_id:
+            await self._remove_embed_message(guild)
+            return False
+
+        channel = guild.get_channel(channel_id)
+        if not isinstance(channel, discord.TextChannel):
+            await self._remove_embed_message(guild)
+            return False
+
+        config = await self._fetch_guild_config(guild.id)
+        provider_label = None
+        requires_login = True
+        if config:
+            provider_label = config.provider_label or config.provider
+            requires_login = config.delivery.requires_login
+
+        return await self._ensure_embed_message(
+            guild,
+            channel,
+            provider_label,
+            requires_login,
+            force=force,
+        )
+
+    async def _ensure_embed_message(
+        self,
+        guild: discord.Guild,
+        channel: discord.TextChannel,
+        provider_label: str | None,
+        requires_login: bool,
+        *,
+        force: bool = False,
+    ) -> bool:
+        record = await mysql.get_captcha_embed_record(guild.id)
+        embed, view = self._build_verification_embed(
+            guild,
+            provider_label,
+            requires_login,
+        )
+
+        if record and record.channel_id == channel.id and not force:
+            try:
+                message = await channel.fetch_message(record.message_id)
+            except (discord.NotFound, discord.HTTPException, discord.Forbidden):
+                message = None
+            if message is not None:
+                try:
+                    await message.edit(embed=embed, view=view)
+                except discord.HTTPException:
+                    _logger.warning(
+                        "Failed to update captcha embed message for guild %s in channel %s",
+                        guild.id,
+                        channel.id,
+                    )
+                    return False
+                await mysql.upsert_captcha_embed_record(guild.id, channel.id, message.id)
+                return True
+
+        if record:
+            await self._remove_embed_message(guild)
+
+        try:
+            message = await channel.send(
+                embed=embed,
+                view=view,
+                allowed_mentions=discord.AllowedMentions.none(),
+            )
+        except discord.Forbidden:
+            _logger.warning(
+                "Missing permissions to send captcha embed in guild %s channel %s",
+                guild.id,
+                channel.id,
+            )
+            return False
+        except discord.HTTPException:
+            _logger.warning(
+                "Failed to send captcha embed in guild %s channel %s",
+                guild.id,
+                channel.id,
+            )
+            return False
+
+        await mysql.upsert_captcha_embed_record(guild.id, channel.id, message.id)
+        return True
+
+    async def _remove_embed_message(self, guild: discord.Guild) -> None:
+        record = await mysql.get_captcha_embed_record(guild.id)
+        if not record:
+            return
+
+        channel = guild.get_channel(record.channel_id)
+        if isinstance(channel, discord.TextChannel):
+            try:
+                message = await channel.fetch_message(record.message_id)
+            except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+                message = None
+            if message is not None:
+                try:
+                    await message.delete()
+                except discord.HTTPException:
+                    _logger.debug(
+                        "Failed to delete existing captcha embed message in guild %s",
+                        guild.id,
+                    )
+
+        await mysql.delete_captcha_embed_record(guild.id)
+
+    def _build_verification_embed(
+        self,
+        guild: discord.Guild,
+        provider_label: str | None,
+        requires_login: bool,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        description = (
+            "Click the button below to verify yourself. Once you pass the captcha, "
+            "you will gain access to the rest of the server."
+        )
+        if requires_login:
+            description += " You may be asked to log in to the Moderator Bot dashboard first."
+
+        embed = discord.Embed(
+            title="Complete Captcha Verification",
+            description=description,
+            colour=discord.Colour.blurple(),
+        )
+        if provider_label:
+            embed.add_field(name="Provider", value=provider_label, inline=True)
+        embed.set_footer(text=f"Guild ID: {guild.id} • Powered by Moderator Bot")
+
+        view = discord.ui.View(timeout=None)
+        view.add_item(
+            discord.ui.Button(
+                label="Verify now",
+                url=self._build_public_verification_url(guild.id),
+                style=discord.ButtonStyle.link,
+            )
+        )
+        return embed, view
+
+    async def _fetch_guild_config(self, guild_id: int) -> CaptchaGuildConfig | None:
+        if not self._api_client.is_configured:
+            return None
+
+        loop = asyncio.get_running_loop()
+        now = loop.time()
+        expires_at = self._config_cache_expiry.get(guild_id)
+        if expires_at and expires_at > now:
+            return self._config_cache.get(guild_id)
+
+        try:
+            config = await self._api_client.fetch_guild_config(guild_id)
+        except (CaptchaApiError, CaptchaNotAvailableError) as exc:
+            _logger.debug(
+                "Failed to fetch captcha configuration for guild %s: %s",
+                guild_id,
+                exc,
+            )
+            self._config_cache.pop(guild_id, None)
+            self._config_cache_expiry.pop(guild_id, None)
+            return None
+
+        self._config_cache[guild_id] = config
+        self._config_cache_expiry[guild_id] = now + self._config_cache_ttl
+        return config
+
+    async def _notify_member_embed(
+        self,
+        member: discord.Member,
+        channel: discord.TextChannel,
+        grace_text: str,
+        max_attempts: int | None,
+    ) -> None:
+        url = self._build_public_verification_url(member.guild.id)
+        description = (
+            f"Hi {member.mention}! To finish joining **{member.guild.name}**, please visit "
+            f"{channel.mention} and complete the captcha within **{grace_text}**."
+        )
+        if max_attempts:
+            attempt_label = "attempt" if max_attempts == 1 else "attempts"
+            description += f" You have **{max_attempts}** {attempt_label}."
+
+        embed = discord.Embed(
+            title="Captcha Verification Required",
+            description=description,
+            color=discord.Color.blurple(),
+        )
+        embed.add_field(
+            name="Need help?",
+            value="Click the button below to open the verification page.",
+            inline=False,
+        )
+        embed.set_footer(text="Powered by Moderator Bot")
+
+        view = discord.ui.View(timeout=None)
+        view.add_item(
+            discord.ui.Button(
+                label="Open verification page",
+                url=url,
+                style=discord.ButtonStyle.link,
+            )
+        )
+
+        try:
+            await member.send(embed=embed, view=view)
+        except (discord.Forbidden, discord.HTTPException):
+            _logger.debug("Failed to DM captcha embed instructions to user %s", member.id)
+
 def _resolve_api_base() -> str:
     raw = os.getenv("CAPTCHA_PUBLIC_VERIFY_URL")
     if not raw:
@@ -328,6 +702,15 @@ def _resolve_api_base() -> str:
 
     rebuilt = parts._replace(path=path, query="", fragment="")
     return urlunsplit(rebuilt).rstrip("/") or _DEFAULT_API_BASE
+
+
+def _resolve_public_verify_url() -> str:
+    raw = os.getenv("CAPTCHA_PUBLIC_VERIFY_URL")
+    if not raw:
+        return _DEFAULT_PUBLIC_VERIFY_URL
+
+    cleaned = raw.strip()
+    return cleaned or _DEFAULT_PUBLIC_VERIFY_URL
 
 async def setup(bot: commands.Bot) -> None:
     cog = CaptchaCog(bot)

--- a/modules/captcha/client.py
+++ b/modules/captcha/client.py
@@ -12,6 +12,8 @@ __all__ = [
     "CaptchaApiError",
     "CaptchaNotAvailableError",
     "CaptchaStartResponse",
+    "CaptchaDeliveryPreferences",
+    "CaptchaGuildConfig",
 ]
 
 class CaptchaApiError(RuntimeError):
@@ -32,6 +34,22 @@ class CaptchaStartResponse:
     verification_url: str
     expires_at: datetime
     state: str | None
+
+
+@dataclass(slots=True)
+class CaptchaDeliveryPreferences:
+    method: str
+    requires_login: bool
+    embed_channel_id: int | None
+
+
+@dataclass(slots=True)
+class CaptchaGuildConfig:
+    guild_id: int
+    delivery: CaptchaDeliveryPreferences
+    provider: str | None
+    provider_label: str | None
+
 
 class CaptchaApiClient:
     """Lightweight HTTP client for the captcha backend."""
@@ -136,6 +154,78 @@ class CaptchaApiClient:
             verification_url=str(verification_url),
             expires_at=expires_at,
             state=state_value if isinstance(state_value, str) else None,
+        )
+
+    async def fetch_guild_config(self, guild_id: int) -> CaptchaGuildConfig:
+        if not self.is_configured:
+            raise CaptchaApiError("Captcha API token or base URL is not configured.")
+
+        session = await self._ensure_session()
+        url = self._base_url
+        headers = {"Authorization": f"Bot {self._api_token}"}
+
+        try:
+            async with session.get(url, params={"gid": str(guild_id)}, headers=headers) as resp:
+                data = await _read_json(resp)
+        except aiohttp.ClientError as exc:
+            raise CaptchaApiError("Failed to contact captcha API.") from exc
+
+        if resp.status == 404:
+            raise CaptchaNotAvailableError(
+                "Captcha is not enabled for this guild.",
+                status=resp.status,
+            )
+        if resp.status == 401:
+            raise CaptchaApiError("Captcha API token is invalid.", status=resp.status)
+        if resp.status >= 400:
+            raise CaptchaApiError(
+                f"Captcha API returned HTTP {resp.status}.",
+                status=resp.status,
+            )
+
+        if not isinstance(data, dict):
+            raise CaptchaApiError("Unexpected response from captcha API.")
+
+        delivery_raw = data.get("delivery")
+        if isinstance(delivery_raw, dict):
+            method = str(delivery_raw.get("method", "dm") or "dm").lower()
+            requires_login = bool(delivery_raw.get("requiresLogin"))
+            embed_channel_raw = delivery_raw.get("embedChannelId")
+        else:
+            method = "dm"
+            requires_login = False
+            embed_channel_raw = None
+
+        embed_channel_id: int | None
+        try:
+            embed_channel_id = int(embed_channel_raw) if embed_channel_raw is not None else None
+        except (TypeError, ValueError):
+            embed_channel_id = None
+
+        captcha_raw = data.get("captcha")
+        provider: str | None = None
+        provider_label: str | None = None
+        if isinstance(captcha_raw, dict):
+            raw_provider = captcha_raw.get("provider")
+            raw_label = captcha_raw.get("label") or captcha_raw.get("providerLabel")
+            provider = str(raw_provider) if isinstance(raw_provider, str) else None
+            provider_label = (
+                str(raw_label)
+                if isinstance(raw_label, str)
+                else (provider.title() if provider else None)
+            )
+
+        delivery = CaptchaDeliveryPreferences(
+            method=method,
+            requires_login=requires_login,
+            embed_channel_id=embed_channel_id,
+        )
+
+        return CaptchaGuildConfig(
+            guild_id=int(data.get("guildId", guild_id) or guild_id),
+            delivery=delivery,
+            provider=provider,
+            provider_label=provider_label,
         )
 
     async def _ensure_session(self) -> aiohttp.ClientSession:

--- a/modules/captcha/processor.py
+++ b/modules/captcha/processor.py
@@ -36,12 +36,17 @@ class CaptchaCallbackProcessor:
                 http_status=404,
             )
 
-        if session.token != payload.token:
-            raise CaptchaProcessingError(
-                "token_mismatch",
-                "Captcha token does not match the pending verification.",
-                http_status=404,
-            )
+        if session.token and session.token != payload.token:
+            if session.delivery_method == "embed":
+                session.token = payload.token
+            else:
+                raise CaptchaProcessingError(
+                    "token_mismatch",
+                    "Captcha token does not match the pending verification.",
+                    http_status=404,
+                )
+        elif not session.token:
+            session.token = payload.token
 
         guild = await self._resolve_guild(payload.guild_id)
         member = await self._resolve_member(guild, payload.user_id)

--- a/modules/captcha/sessions.py
+++ b/modules/captcha/sessions.py
@@ -14,10 +14,11 @@ class CaptchaSession:
 
     guild_id: int
     user_id: int
-    token: str
+    token: str | None
     expires_at: datetime
     state: str | None = None
     redirect: str | None = None
+    delivery_method: str = "dm"
 
     def is_expired(self, now: datetime | None = None) -> bool:
         if now is None:

--- a/modules/config/settings_schema.py
+++ b/modules/config/settings_schema.py
@@ -492,6 +492,20 @@ SETTINGS_SCHEMA = {
         default=[],
         hidden=True,
     ),
+    "captcha-delivery-method": Setting(
+        name="captcha-delivery-method",
+        description="How captcha verification links are delivered to new members (dm or embed).",
+        setting_type=str,
+        default="dm",
+        choices=["dm", "embed"],
+        hidden=True,
+    ),
+    "captcha-embed-channel-id": Setting(
+        name="captcha-embed-channel-id",
+        description="Channel where the captcha verification embed is posted when using embed delivery.",
+        setting_type=discord.TextChannel,
+        hidden=True,
+    ),
     "pre-captcha-roles": Setting(
         name="pre-captcha-roles",
         description="Roles assigned to newcomers before they complete captcha verification.",

--- a/modules/utils/mysql/__init__.py
+++ b/modules/utils/mysql/__init__.py
@@ -6,7 +6,12 @@ from .connection import (
     init_pool,
     initialise_and_get_pool,
 )
-from .settings import get_settings, update_settings
+from .settings import (
+    add_settings_listener,
+    get_settings,
+    remove_settings_listener,
+    update_settings,
+)
 from .strikes import cleanup_expired_strikes, get_strike_count, get_strikes
 from .usage import add_aimod_usage, add_vcmod_usage, get_aimod_usage, get_vcmod_usage
 from .cleanup import cleanup_orphaned_guilds
@@ -20,6 +25,12 @@ from .premium import (
 from .instances import (
     clear_instance_heartbeat,
     update_instance_heartbeat,
+)
+from .captcha import (
+    CaptchaEmbedRecord,
+    delete_captcha_embed_record,
+    get_captcha_embed_record,
+    upsert_captcha_embed_record,
 )
 
 from .shards import (
@@ -45,6 +56,8 @@ __all__ = [
     "cleanup_expired_strikes",
     "get_settings",
     "update_settings",
+    "add_settings_listener",
+    "remove_settings_listener",
     "get_aimod_usage",
     "add_aimod_usage",
     "get_vcmod_usage",
@@ -57,6 +70,10 @@ __all__ = [
     "remove_guild",
     "update_instance_heartbeat",
     "clear_instance_heartbeat",
+    "CaptchaEmbedRecord",
+    "get_captcha_embed_record",
+    "upsert_captcha_embed_record",
+    "delete_captcha_embed_record",
     "ShardAssignment",
     "ShardClaimError",
     "claim_shard",

--- a/modules/utils/mysql/captcha.py
+++ b/modules/utils/mysql/captcha.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .connection import execute_query
+
+
+@dataclass(slots=True)
+class CaptchaEmbedRecord:
+    """Represents the stored captcha verification embed for a guild."""
+
+    guild_id: int
+    channel_id: int
+    message_id: int
+
+
+async def get_captcha_embed_record(guild_id: int) -> CaptchaEmbedRecord | None:
+    """Fetch the stored captcha embed metadata for the given guild."""
+
+    row, _ = await execute_query(
+        "SELECT channel_id, message_id FROM captcha_embeds WHERE guild_id = %s",
+        (guild_id,),
+        fetch_one=True,
+    )
+    if not row:
+        return None
+
+    channel_id_raw, message_id_raw = row
+    try:
+        channel_id = int(channel_id_raw)
+        message_id = int(message_id_raw)
+    except (TypeError, ValueError):
+        return None
+
+    return CaptchaEmbedRecord(
+        guild_id=guild_id,
+        channel_id=channel_id,
+        message_id=message_id,
+    )
+
+
+async def upsert_captcha_embed_record(
+    guild_id: int,
+    channel_id: int,
+    message_id: int,
+) -> None:
+    """Store or update the captcha embed metadata for a guild."""
+
+    await execute_query(
+        """
+        INSERT INTO captcha_embeds (guild_id, channel_id, message_id)
+        VALUES (%s, %s, %s)
+        ON DUPLICATE KEY UPDATE
+            channel_id = VALUES(channel_id),
+            message_id = VALUES(message_id),
+            updated_at = CURRENT_TIMESTAMP
+        """,
+        (guild_id, channel_id, message_id),
+    )
+
+
+async def delete_captcha_embed_record(guild_id: int) -> None:
+    """Remove any stored captcha embed metadata for the guild."""
+
+    await execute_query(
+        "DELETE FROM captcha_embeds WHERE guild_id = %s",
+        (guild_id,),
+    )

--- a/modules/utils/mysql/connection.py
+++ b/modules/utils/mysql/connection.py
@@ -180,6 +180,16 @@ async def _ensure_database_exists() -> None:
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
                 """
             )
+            await cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS captcha_embeds (
+                    guild_id BIGINT PRIMARY KEY,
+                    channel_id BIGINT NOT NULL,
+                    message_id BIGINT NOT NULL,
+                    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+                """
+            )
             await conn.commit()
         finally:
             conn.close()


### PR DESCRIPTION
## Summary
- add guild settings and database support for tracking captcha verification embeds
- implement embed delivery flow in the captcha cog, including automatic sync on setting updates and a manual sync command
- extend the captcha API client and session handling to support embed delivery and update associated tests

## Testing
- pytest

------