### PR TITLE
Handle missing parent on_interaction handler

### DIFF
--- a/modules/core/moderator_bot.py
+++ b/modules/core/moderator_bot.py
@@ -220,7 +220,13 @@ class ModeratorBot(commands.Bot):
         locale = self._extract_locale_from_interaction(interaction)
         token = _current_locale.set(locale)
         try:
-            await super().on_interaction(interaction)
+            try:
+                parent_on_interaction = super().on_interaction  # type: ignore[attr-defined]
+            except AttributeError:
+                parent_on_interaction = None
+
+            if parent_on_interaction is not None:
+                await parent_on_interaction(interaction)
         finally:
             _current_locale.reset(token)
 


### PR DESCRIPTION
## Summary
- prevent ModeratorBot from raising AttributeError when the base class lacks on_interaction by guarding the super() call

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d97dca964c832d8b12b8fb088e61e3