### PR TITLE
Localize strike messaging to locale files

### DIFF
--- a/locales/en-US/modules.moderation.strike.json
+++ b/locales/en-US/modules.moderation.strike.json
@@ -50,7 +50,15 @@
           "reason": "**Reason:** {reason}",
           "expires": "**Expires:** {expiry}",
           "issued_by": "Issued By",
-          "expiry_never": "Never"
+          "expiry_never": "Never",
+          "footer": "Server: {server}"
+        },
+        "warn_embed": {
+          "title": "⚠️ You Have Been Warned",
+          "description": "{mention}, {message}\n\n{reason_block}{reminder}",
+          "reason_block": "**Reason:** {reason}\n\n",
+          "reminder": "Please follow the server rules to avoid further action such as timeouts, strikes, or bans.",
+          "footer": "Server: {server}"
         },
         "errors": {
           "too_many_strikes": "You cannot give the same player more than 100 strikes. Use `/strikes clear <user>` to reset their strikes."

--- a/locales/en/modules.moderation.strike.json
+++ b/locales/en/modules.moderation.strike.json
@@ -50,7 +50,15 @@
           "reason": "**Reason:** {reason}",
           "expires": "**Expires:** {expiry}",
           "issued_by": "Issued By",
-          "expiry_never": "Never"
+          "expiry_never": "Never",
+          "footer": "Server: {server}"
+        },
+        "warn_embed": {
+          "title": "⚠️ You Have Been Warned",
+          "description": "{mention}, {message}\n\n{reason_block}{reminder}",
+          "reason_block": "**Reason:** {reason}\n\n",
+          "reminder": "Please follow the server rules to avoid further action such as timeouts, strikes, or bans.",
+          "footer": "Server: {server}"
         },
         "errors": {
           "too_many_strikes": "You cannot give the same player more than 100 strikes. Use `/strikes clear <user>` to reset their strikes."


### PR DESCRIPTION
## Summary
- replace the hard-coded strike and disciplinary strings with locale-driven translations and fallbacks
- add warn embed and footer strings to the English locale files for strike messaging

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d97f88c81c832d9c560558ea2b7bfd