### PR TITLE
Expand locale alias coverage for all translations

### DIFF
--- a/modules/core/moderator_bot.py
+++ b/modules/core/moderator_bot.py
@@ -16,57 +16,61 @@ from modules.i18n import LocaleRepository, Translator
 
 _current_locale: ContextVar[str | None] = ContextVar("moderator_bot_locale", default=None)
 
-SUPPORTED_LOCALE_ALIASES: dict[str, str] = {
-    "bg": "bg",
-    "cs": "cs",
-    "da": "da",
-    "de": "de",
-    "de-de": "de",
-    "el": "el",
-    "es": "es",
-    "es-es": "es",
-    "es-419": "es",
-    "fi": "fi",
-    "fr": "fr",
-    "fr-fr": "fr",
-    "hi": "hi",
-    "hr": "hr",
-    "hu": "hu",
-    "id": "id",
-    "it": "it",
-    "ja": "ja",
-    "ko": "ko",
-    "lt": "lt",
-    "nl": "nl",
-    "no": "no",
-    "pl": "pl",
-    "pt": "pt",
-    "pt-pt": "pt",
-    "pt-br": "pt-BR",
-    "ro": "ro",
-    "ru": "ru",
-    "sk": "sk",
-    "sr": "sr",
-    "sv": "sv-SE",
-    "sv-se": "sv-SE",
-    "th": "th",
-    "tr": "tr",
-    "uk": "uk",
-    "vi": "vi",
-    "zh": "zh-CN",
-    "zh-cn": "zh-CN",
-    "zh-tw": "zh-TW",
-    "zh-hk": "zh-TW",
-    "en": "en",
-    "en-us": "en",
-    "en-gb": "en",
-    "en-ca": "en",
-    "en-au": "en",
-    "en-nz": "en",
-    "en-ie": "en",
-    "en-in": "en",
-    "en-za": "en",
-}
+def _build_locale_aliases() -> dict[str, str]:
+    mapping: dict[str, str] = {}
+
+    def register(canonical: str, *aliases: str) -> None:
+        normalized_canonical = canonical.strip().replace("_", "-")
+        if not normalized_canonical:
+            return
+        for candidate in (canonical, *aliases):
+            normalized = candidate.strip().replace("_", "-")
+            if not normalized:
+                continue
+            mapping[normalized.lower()] = normalized_canonical
+
+    register("af-ZA", "af")
+    register("ar-SA", "ar")
+    register("bg")
+    register("ca-ES", "ca")
+    register("cs-CZ", "cs")
+    register("da-DK", "da")
+    register("de-DE", "de")
+    register("el-GR", "el")
+    register("en", "en-US", "en-GB", "en-CA", "en-AU", "en-NZ", "en-IE", "en-IN", "en-ZA")
+    register("es-ES", "es", "es-419")
+    register("fi-FI", "fi")
+    register("fr-FR", "fr")
+    register("he-IL", "he")
+    register("hi")
+    register("hr")
+    register("hu-HU", "hu")
+    register("id")
+    register("it-IT", "it")
+    register("ja-JP", "ja")
+    register("ko-KR", "ko")
+    register("lt")
+    register("nl-NL", "nl")
+    register("no-NO", "no")
+    register("pl-PL", "pl")
+    register("pt-PT", "pt")
+    register("pt-BR")
+    register("ro-RO", "ro")
+    register("ru-RU", "ru")
+    register("sk")
+    register("sr-SP", "sr")
+    register("sv-SE", "sv")
+    register("th")
+    register("tr-TR", "tr")
+    register("uk-UA", "uk")
+    register("vi-VN", "vi")
+    register("zh-CN", "zh")
+    register("zh-TW", "zh-HK")
+
+    return mapping
+
+
+SUPPORTED_LOCALE_ALIASES: dict[str, str] = _build_locale_aliases()
 
 _logger = logging.getLogger(__name__)
 

--- a/tests/test_moderator_bot_locale.py
+++ b/tests/test_moderator_bot_locale.py
@@ -66,7 +66,7 @@ def test_context_uses_guild_preference(bot: ModeratorBot) -> None:
 
     resolved = bot._infer_locale_from_event("command", (ctx,), {})
 
-    assert resolved == "es"
+    assert resolved == "es-ES"
 
 
 def test_guild_override_has_priority(
@@ -91,7 +91,7 @@ def test_guild_override_has_priority(
 
     resolved = bot._infer_locale_from_event("interaction", (interaction,), {})
 
-    assert resolved == "fr"
+    assert resolved == "fr-FR"
 
 
 def test_unsupported_locale_rejects_value(bot: ModeratorBot) -> None:
@@ -106,8 +106,42 @@ def test_translate_defaults_without_context(bot: ModeratorBot) -> None:
     assert result == "Open Dashboard"
 
 
+LOCALIZED_WELCOME_LABELS: dict[str, str] = {
+    "es-ES": "Abrir Panel de control",
+    "fr-FR": "Ouvrir le tableau de bord",
+    "pl-PL": "Otwórz Panel",
+    "pt-PT": "Abrir Painel de Controle",
+    "ru-RU": "Открыть панель управления",
+    "sv-SE": "Öppna Instrumentpanel",
+    "vi-VN": "Mở bảng điều khiển",
+    "zh-CN": "打开仪表板",
+}
+
+LOCALE_ALIAS_EXPECTATIONS = [
+    *[(canonical, label) for canonical, label in LOCALIZED_WELCOME_LABELS.items()],
+    ("es", LOCALIZED_WELCOME_LABELS["es-ES"]),
+    ("es-419", LOCALIZED_WELCOME_LABELS["es-ES"]),
+    ("fr", LOCALIZED_WELCOME_LABELS["fr-FR"]),
+    ("pl", LOCALIZED_WELCOME_LABELS["pl-PL"]),
+    ("pt", LOCALIZED_WELCOME_LABELS["pt-PT"]),
+    ("ru", LOCALIZED_WELCOME_LABELS["ru-RU"]),
+    ("sv", LOCALIZED_WELCOME_LABELS["sv-SE"]),
+    ("vi", LOCALIZED_WELCOME_LABELS["vi-VN"]),
+    ("zh", LOCALIZED_WELCOME_LABELS["zh-CN"]),
+]
+
+
+@pytest.mark.parametrize("locale_hint,expected", LOCALE_ALIAS_EXPECTATIONS)
+def test_locale_aliases_use_translated_welcome_button(
+    bot: ModeratorBot, locale_hint: str, expected: str
+) -> None:
+    result = bot.translate("bot.welcome.button_label", locale=locale_hint)
+
+    assert result == expected
+
+
 def test_locale_context_manager_restores_previous_locale(bot: ModeratorBot) -> None:
     with bot.locale_context("fr-FR"):
-        assert _current_locale.get() == "fr"
+        assert _current_locale.get() == "fr-FR"
 
     assert _current_locale.get() is None


### PR DESCRIPTION
## Summary
- expand locale alias normalization to cover every supported translation and consolidate mapping logic
- verify welcome button translations across locale aliases for all localized languages and update expectations to canonical codes

## Testing
- pytest tests/test_moderator_bot_locale.py

------
https://chatgpt.com/codex/tasks/task_e_68d980d4b1a8832d9986e7ce5d164dc0