### PR TITLE
Add locale override setting with validation

### DIFF
--- a/modules/config/settings_schema.py
+++ b/modules/config/settings_schema.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, Optional
 from collections.abc import Iterable
 import discord
 from modules.config.premium_plans import PLAN_CORE, PLAN_PRO, PLAN_ULTRA, resolve_required_plans
+from modules.i18n.locale_utils import list_supported_locales, normalise_locale
 from modules.variables.TimeString import TimeString
 
 class Setting:
@@ -35,6 +36,19 @@ class Setting:
     async def validate(self, value: Any):
         if self.validator:
             await self.validator(value)
+
+
+async def _validate_locale(value: Any) -> None:
+    if value is None:
+        return
+
+    normalized = normalise_locale(value)
+    if not normalized:
+        supported = ", ".join(list_supported_locales())
+        raise ValueError(
+            "Invalid locale. Supported locales: "
+            f"{supported}"
+        )
 
 SETTINGS_SCHEMA = {
     "strike-channel": Setting(
@@ -85,6 +99,13 @@ SETTINGS_SCHEMA = {
             "message_edit": True,
             },
         hidden=True
+    ),
+    "locale": Setting(
+        name="locale",
+        description="Override automatic locale detection with a specific locale code.",
+        setting_type=str,
+        default=None,
+        validator=_validate_locale,
     ),
     "nsfw-detection-action": Setting(
         name="nsfw-detection-action",

--- a/modules/core/moderator_bot.py
+++ b/modules/core/moderator_bot.py
@@ -13,64 +13,9 @@ from discord.ext import commands, tasks
 from modules.post_stats.topgg_poster import start_topgg_poster
 from modules.utils import mysql
 from modules.i18n import LocaleRepository, Translator
+from modules.i18n.locale_utils import SUPPORTED_LOCALE_ALIASES, normalise_locale
 
 _current_locale: ContextVar[str | None] = ContextVar("moderator_bot_locale", default=None)
-
-def _build_locale_aliases() -> dict[str, str]:
-    mapping: dict[str, str] = {}
-
-    def register(canonical: str, *aliases: str) -> None:
-        normalized_canonical = canonical.strip().replace("_", "-")
-        if not normalized_canonical:
-            return
-        for candidate in (canonical, *aliases):
-            normalized = candidate.strip().replace("_", "-")
-            if not normalized:
-                continue
-            mapping[normalized.lower()] = normalized_canonical
-
-    register("af-ZA", "af")
-    register("ar-SA", "ar")
-    register("bg")
-    register("ca-ES", "ca")
-    register("cs-CZ", "cs")
-    register("da-DK", "da")
-    register("de-DE", "de")
-    register("el-GR", "el")
-    register("en", "en-US", "en-GB", "en-CA", "en-AU", "en-NZ", "en-IE", "en-IN", "en-ZA")
-    register("es-ES", "es", "es-419")
-    register("fi-FI", "fi")
-    register("fr-FR", "fr")
-    register("he-IL", "he")
-    register("hi")
-    register("hr")
-    register("hu-HU", "hu")
-    register("id")
-    register("it-IT", "it")
-    register("ja-JP", "ja")
-    register("ko-KR", "ko")
-    register("lt")
-    register("nl-NL", "nl")
-    register("no-NO", "no")
-    register("pl-PL", "pl")
-    register("pt-PT", "pt")
-    register("pt-BR")
-    register("ro-RO", "ro")
-    register("ru-RU", "ru")
-    register("sk")
-    register("sr-SP", "sr")
-    register("sv-SE", "sv")
-    register("th")
-    register("tr-TR", "tr")
-    register("uk-UA", "uk")
-    register("vi-VN", "vi")
-    register("zh-CN", "zh")
-    register("zh-TW", "zh-HK")
-
-    return mapping
-
-
-SUPPORTED_LOCALE_ALIASES: dict[str, str] = _build_locale_aliases()
 
 _logger = logging.getLogger(__name__)
 
@@ -343,17 +288,7 @@ class ModeratorBot(commands.Bot):
         return None
 
     def _normalise_locale(self, locale: Any) -> str | None:
-        if locale is None:
-            return None
-        if isinstance(locale, discord.Locale):
-            raw = locale.value
-        else:
-            raw = str(locale)
-        normalized = raw.strip().replace("_", "-")
-        if not normalized:
-            return None
-        mapped = SUPPORTED_LOCALE_ALIASES.get(normalized.lower())
-        return mapped
+        return normalise_locale(locale)
 
     async def refresh_guild_locale_override(self, guild_id: int) -> None:
         try:

--- a/modules/i18n/locale_utils.py
+++ b/modules/i18n/locale_utils.py
@@ -1,0 +1,106 @@
+"""Helpers for working with Moderator Bot locale codes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import discord
+
+
+def _build_locale_aliases() -> dict[str, str]:
+    mapping: dict[str, str] = {}
+
+    def register(canonical: str, *aliases: str) -> None:
+        normalized_canonical = canonical.strip().replace("_", "-")
+        if not normalized_canonical:
+            return
+        for candidate in (canonical, *aliases):
+            normalized = candidate.strip().replace("_", "-")
+            if not normalized:
+                continue
+            mapping[normalized.lower()] = normalized_canonical
+
+    register("af-ZA", "af")
+    register("ar-SA", "ar")
+    register("bg")
+    register("ca-ES", "ca")
+    register("cs-CZ", "cs")
+    register("da-DK", "da")
+    register("de-DE", "de")
+    register("el-GR", "el")
+    register(
+        "en",
+        "en-US",
+        "en-GB",
+        "en-CA",
+        "en-AU",
+        "en-NZ",
+        "en-IE",
+        "en-IN",
+        "en-ZA",
+    )
+    register("es-ES", "es", "es-419")
+    register("fi-FI", "fi")
+    register("fr-FR", "fr")
+    register("he-IL", "he")
+    register("hi")
+    register("hr")
+    register("hu-HU", "hu")
+    register("id")
+    register("it-IT", "it")
+    register("ja-JP", "ja")
+    register("ko-KR", "ko")
+    register("lt")
+    register("nl-NL", "nl")
+    register("no-NO", "no")
+    register("pl-PL", "pl")
+    register("pt-PT", "pt")
+    register("pt-BR")
+    register("ro-RO", "ro")
+    register("ru-RU", "ru")
+    register("sk")
+    register("sr-SP", "sr")
+    register("sv-SE", "sv")
+    register("th")
+    register("tr-TR", "tr")
+    register("uk-UA", "uk")
+    register("vi-VN", "vi")
+    register("zh-CN", "zh")
+    register("zh-TW", "zh-HK")
+
+    return mapping
+
+
+SUPPORTED_LOCALE_ALIASES: dict[str, str] = _build_locale_aliases()
+
+
+def normalise_locale(locale: Any) -> str | None:
+    """Return the canonical locale for *locale* or ``None`` if unsupported."""
+
+    if locale is None:
+        return None
+
+    if isinstance(locale, discord.Locale):
+        raw = locale.value
+    else:
+        raw = str(locale)
+
+    normalized = raw.strip().replace("_", "-")
+    if not normalized:
+        return None
+
+    mapped = SUPPORTED_LOCALE_ALIASES.get(normalized.lower())
+    return mapped
+
+
+def list_supported_locales() -> list[str]:
+    """Return the canonical locale codes supported by the bot."""
+
+    return sorted({alias for alias in SUPPORTED_LOCALE_ALIASES.values()})
+
+
+__all__ = [
+    "SUPPORTED_LOCALE_ALIASES",
+    "normalise_locale",
+    "list_supported_locales",
+]

--- a/tests/test_moderator_bot_locale.py
+++ b/tests/test_moderator_bot_locale.py
@@ -13,6 +13,7 @@ os.environ.setdefault(
 )
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+from modules.config.settings_schema import SETTINGS_SCHEMA
 from modules.core.moderator_bot import ModeratorBot, _current_locale
 from modules.utils import mysql
 
@@ -145,3 +146,12 @@ def test_locale_context_manager_restores_previous_locale(bot: ModeratorBot) -> N
         assert _current_locale.get() == "fr-FR"
 
     assert _current_locale.get() is None
+
+
+def test_locale_setting_validator_accepts_supported_locale() -> None:
+    asyncio.run(SETTINGS_SCHEMA["locale"].validate("fr-FR"))
+
+
+def test_locale_setting_validator_rejects_unknown_locale() -> None:
+    with pytest.raises(ValueError):
+        asyncio.run(SETTINGS_SCHEMA["locale"].validate("zz-ZZ"))


### PR DESCRIPTION
## Summary
- expose the locale override setting so guilds can manually control translation language
- share locale normalisation helpers between the bot and settings validation
- cover the new locale validator with unit tests

## Testing
- pytest

------