### PR TITLE
Store guild preferred locales in database

### DIFF
--- a/modules/utils/mysql/connection.py
+++ b/modules/utils/mysql/connection.py
@@ -175,11 +175,27 @@ async def _ensure_database_exists() -> None:
                     guild_id BIGINT PRIMARY KEY,
                     name VARCHAR(255) NOT NULL,
                     owner_id BIGINT NOT NULL,
+                    locale VARCHAR(16) NULL,
                     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
                     UNIQUE KEY (guild_id)
                 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
                 """
             )
+            await cur.execute(
+                """
+                SELECT 1
+                FROM INFORMATION_SCHEMA.COLUMNS
+                WHERE table_schema = DATABASE()
+                  AND table_name = 'guilds'
+                  AND column_name = 'locale'
+                LIMIT 1
+                """
+            )
+            locale_column = await cur.fetchone()
+            if not locale_column:
+                await cur.execute(
+                    "ALTER TABLE guilds ADD COLUMN locale VARCHAR(16) NULL DEFAULT NULL AFTER owner_id"
+                )
             await cur.execute(
                 """
                 CREATE TABLE IF NOT EXISTS captcha_embeds (

--- a/modules/utils/mysql/premium.py
+++ b/modules/utils/mysql/premium.py
@@ -100,15 +100,20 @@ async def resolve_guild_plan(guild_id: int) -> str:
     plan = tier_to_plan(tier, default=PLAN_CORE)
     return plan or PLAN_CORE
 
-async def add_guild(guild_id: int, name: str, owner_id: int):
+async def add_guild(
+    guild_id: int, name: str, owner_id: int, locale: Optional[str]
+):
     """Add a new guild to the database."""
     await execute_query(
         """
-        INSERT INTO guilds (guild_id, name, owner_id)
-        VALUES (%s, %s, %s)
-        ON DUPLICATE KEY UPDATE name = VALUES(name), owner_id = VALUES(owner_id)
+        INSERT INTO guilds (guild_id, name, owner_id, locale)
+        VALUES (%s, %s, %s, %s)
+        ON DUPLICATE KEY UPDATE
+            name = VALUES(name),
+            owner_id = VALUES(owner_id),
+            locale = VALUES(locale)
         """,
-        (guild_id, name, owner_id),
+        (guild_id, name, owner_id, locale),
     )
 
 

--- a/tests/test_moderator_bot_locale.py
+++ b/tests/test_moderator_bot_locale.py
@@ -28,7 +28,6 @@ class DummyContext(SimpleNamespace):
 
 
 class DummyInteraction(SimpleNamespace):
-    guild_locale: str | None
     guild: DummyGuild | None
     locale: str | None
     guild_id: int | None
@@ -47,10 +46,9 @@ def bot() -> ModeratorBot:
     mysql.remove_settings_listener(bot._locale_settings_listener)
 
 
-def test_interaction_locale_normalises_discord_hint(bot: ModeratorBot) -> None:
-    guild = DummyGuild(id=123, preferred_locale=None)
+def test_interaction_locale_uses_preferred_locale(bot: ModeratorBot) -> None:
+    guild = DummyGuild(id=123, preferred_locale="en-US")
     interaction = DummyInteraction(
-        guild_locale="en-US",
         guild=guild,
         locale=None,
         guild_id=guild.id,
@@ -84,7 +82,6 @@ def test_guild_override_has_priority(
 
     guild = DummyGuild(id=789, preferred_locale="en-US")
     interaction = DummyInteraction(
-        guild_locale="de-DE",
         guild=guild,
         locale=None,
         guild_id=guild.id,


### PR DESCRIPTION
## Summary
- add a locale column to the guilds table and ensure it exists for existing databases
- persist each guild's preferred locale and reuse the cached value during locale resolution
- update locale detection tests to reflect the new preferred-locale behaviour

## Testing
- pytest

------