### PR TITLE
Enforce canonical locale overrides and tidy MySQL setup

### DIFF
--- a/modules/config/settings_schema.py
+++ b/modules/config/settings_schema.py
@@ -43,7 +43,10 @@ async def _validate_locale(value: Any) -> None:
         return
 
     normalized = normalise_locale(value)
-    if not normalized:
+    raw_value = getattr(value, "value", value)
+    candidate = str(raw_value).strip().replace("_", "-") if raw_value is not None else ""
+
+    if not normalized or candidate.lower() != normalized.lower():
         supported = ", ".join(list_supported_locales())
         raise ValueError(
             "Invalid locale. Supported locales: "
@@ -106,6 +109,7 @@ SETTINGS_SCHEMA = {
         setting_type=str,
         default=None,
         validator=_validate_locale,
+        choices=list_supported_locales(),
     ),
     "nsfw-detection-action": Setting(
         name="nsfw-detection-action",

--- a/modules/utils/mysql/connection.py
+++ b/modules/utils/mysql/connection.py
@@ -183,21 +183,6 @@ async def _ensure_database_exists() -> None:
             )
             await cur.execute(
                 """
-                SELECT 1
-                FROM INFORMATION_SCHEMA.COLUMNS
-                WHERE table_schema = DATABASE()
-                  AND table_name = 'guilds'
-                  AND column_name = 'locale'
-                LIMIT 1
-                """
-            )
-            locale_column = await cur.fetchone()
-            if not locale_column:
-                await cur.execute(
-                    "ALTER TABLE guilds ADD COLUMN locale VARCHAR(16) NULL DEFAULT NULL AFTER owner_id"
-                )
-            await cur.execute(
-                """
                 CREATE TABLE IF NOT EXISTS captcha_embeds (
                     guild_id BIGINT PRIMARY KEY,
                     channel_id BIGINT NOT NULL,

--- a/tests/test_moderator_bot_locale.py
+++ b/tests/test_moderator_bot_locale.py
@@ -14,6 +14,7 @@ os.environ.setdefault(
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from modules.config.settings_schema import SETTINGS_SCHEMA
+from modules.i18n.locale_utils import list_supported_locales
 from modules.core.moderator_bot import ModeratorBot, _current_locale
 from modules.utils import mysql
 
@@ -145,10 +146,20 @@ def test_locale_context_manager_restores_previous_locale(bot: ModeratorBot) -> N
     assert _current_locale.get() is None
 
 
-def test_locale_setting_validator_accepts_supported_locale() -> None:
-    asyncio.run(SETTINGS_SCHEMA["locale"].validate("fr-FR"))
+@pytest.mark.parametrize("candidate", ["fr-FR", "vi-VN"])
+def test_locale_setting_validator_accepts_supported_locale(candidate: str) -> None:
+    asyncio.run(SETTINGS_SCHEMA["locale"].validate(candidate))
 
 
 def test_locale_setting_validator_rejects_unknown_locale() -> None:
     with pytest.raises(ValueError):
         asyncio.run(SETTINGS_SCHEMA["locale"].validate("zz-ZZ"))
+
+
+def test_locale_setting_validator_rejects_alias_locales() -> None:
+    with pytest.raises(ValueError):
+        asyncio.run(SETTINGS_SCHEMA["locale"].validate("vi"))
+
+
+def test_locale_setting_choices_list_supported_locales() -> None:
+    assert SETTINGS_SCHEMA["locale"].choices == list_supported_locales()


### PR DESCRIPTION
## Summary
- expose the supported locale list as selectable choices and require canonical codes when validating locale overrides
- expand locale-setting tests to cover canonical and alias inputs, guarding against regressions such as the vi-VN override
- remove the legacy ALTER TABLE fallback from the MySQL guilds table bootstrap

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9920c83f0832d9bc09fdec81209e0