### PR TITLE
Localize autonomous moderator reply messages

### DIFF
--- a/cogs/autonomous_moderation/autonomous_moderator.py
+++ b/cogs/autonomous_moderation/autonomous_moderator.py
@@ -184,13 +184,38 @@ class AutonomousModeratorCog(commands.Cog):
             if not guild:
                 continue
 
+            guild_locale = self.bot._guild_locales.resolve(guild)
+
             # Budget notification if applicable
             if report is None and trigger_msg and status == "budget":
                 try:
                     cycle_end = usage.get("cycle_end")
-                    reset_str = cycle_end.strftime('%Y-%m-%d %H:%M UTC') if cycle_end else "the next cycle"
+                    reset_label = (
+                        self.bot.translate(
+                            "cogs.autonomous_moderation.moderator.budget_reset_time",
+                            locale=guild_locale,
+                            placeholders={
+                                "time": cycle_end.strftime('%Y-%m-%d %H:%M UTC')
+                            },
+                            fallback=cycle_end.strftime('%Y-%m-%d %H:%M UTC'),
+                        )
+                        if cycle_end
+                        else self.bot.translate(
+                            "cogs.autonomous_moderation.moderator.budget_reset_next",
+                            locale=guild_locale,
+                            fallback="the next cycle",
+                        )
+                    )
                     await trigger_msg.reply(
-                        f"AI moderation budget reached for this billing cycle. Resets at {reset_str}.",
+                        self.bot.translate(
+                            "cogs.autonomous_moderation.moderator.budget_reached",
+                            locale=guild_locale,
+                            placeholders={"reset": reset_label},
+                            fallback=(
+                                "AI moderation budget reached for this billing cycle. "
+                                f"Resets at {reset_label}."
+                            ),
+                        ),
                         mention_author=False,
                     )
                 except discord.HTTPException:
@@ -206,7 +231,13 @@ class AutonomousModeratorCog(commands.Cog):
             if not report or not report.violations:
                 if trigger_msg:
                     try:
-                        await trigger_msg.reply("Thanks for the report. No violations were found.")
+                        await trigger_msg.reply(
+                            self.bot.translate(
+                                "cogs.autonomous_moderation.moderator.thanks_no_violation",
+                                locale=guild_locale,
+                                fallback="Thanks for the report. No violations were found.",
+                            )
+                        )
                     except discord.HTTPException:
                         pass
                 # Always log to AI violations channel when debug is enabled
@@ -253,7 +284,13 @@ class AutonomousModeratorCog(commands.Cog):
 
             if trigger_msg:
                 try:
-                    await trigger_msg.reply("Thanks for the report. Action was taken.")
+                    await trigger_msg.reply(
+                        self.bot.translate(
+                            "cogs.autonomous_moderation.moderator.thanks_action",
+                            locale=guild_locale,
+                            fallback="Thanks for the report. Action was taken.",
+                        )
+                    )
                 except discord.HTTPException:
                     pass
 

--- a/locales/en-US/cogs.autonomous_moderation.json
+++ b/locales/en-US/cogs.autonomous_moderation.json
@@ -42,6 +42,13 @@
         "detail_time": "`{value}`",
         "detail_threshold": "{display} — `{threshold}`"
       },
+      "moderator": {
+        "budget_reached": "AI moderation budget reached for this billing cycle. Resets at {reset}.",
+        "budget_reset_time": "{time}",
+        "budget_reset_next": "the next cycle",
+        "thanks_no_violation": "Thanks for the report. No violations were found.",
+        "thanks_action": "Thanks for the report. Action was taken."
+      },
       "ensure_adaptive": "Adaptive moderation mode is not enabled. Use `/ai_mod set_mode` to enable it."
     }
   }

--- a/locales/en/cogs.autonomous_moderation.json
+++ b/locales/en/cogs.autonomous_moderation.json
@@ -42,6 +42,13 @@
         "detail_time": "`{value}`",
         "detail_threshold": "{display} — `{threshold}`"
       },
+      "moderator": {
+        "budget_reached": "AI moderation budget reached for this billing cycle. Resets at {reset}.",
+        "budget_reset_time": "{time}",
+        "budget_reset_next": "the next cycle",
+        "thanks_no_violation": "Thanks for the report. No violations were found.",
+        "thanks_action": "Thanks for the report. Action was taken."
+      },
       "ensure_adaptive": "Adaptive moderation mode is not enabled. Use `/ai_mod set_mode` to enable it."
     }
   }


### PR DESCRIPTION
## Summary
- translate the autonomous moderator's reply and budget notifications through the locale service
- add locale strings for the moderator thank-you and budget messages

## Testing
- pytest tests/test_moderator_bot_locale.py

------