### PR TITLE
Localize API pool validation errors

### DIFF
--- a/LOCALIZATION_PROGRESS.md
+++ b/LOCALIZATION_PROGRESS.md
@@ -1,0 +1,10 @@
+# Localization Progress
+
+## Completed
+- [x] modules/utils/api.py — Added a structured validation error for OpenAI API keys with locale-backed messaging.
+- [x] cogs/api_pool.py — Localized API key validation responses using the new translator-aware error details.
+
+## To Do
+- [ ] cogs/nsfw.py — Slash command descriptions and choice labels remain hard-coded.
+- [ ] cogs/banned_words.py — Slash command descriptions are currently hard-coded.
+- [ ] Audit other slash-command metadata across remaining cogs for hard-coded descriptions.

--- a/locales/en/modules.utils.api.json
+++ b/locales/en/modules.utils.api.json
@@ -2,7 +2,10 @@
   "modules": {
     "utils": {
       "api": {
-        "key_failed_notice": "**Warning:** Your OpenAI API key failed a moderation check.\n\nThis usually means your account does not have active billing or is temporarily rate-limited.\n\nPlease check your [OpenAI Billing Dashboard](https://platform.openai.com/account/billing/overview) to ensure your account has payment info and at least $5 in credits.\n\nOnce that is resolved, your key will automatically start working again - no need to re-add it."
+        "key_failed_notice": "**Warning:** Your OpenAI API key failed a moderation check.\n\nThis usually means your account does not have active billing or is temporarily rate-limited.\n\nPlease check your [OpenAI Billing Dashboard](https://platform.openai.com/account/billing/overview) to ensure your account has payment info and at least $5 in credits.\n\nOnce that is resolved, your key will automatically start working again - no need to re-add it.",
+        "key_validation": {
+          "billing_required": "Your API key didn't work. This is likely because your organization hasn't added any credit to its OpenAI account. Even though the moderation model is free, OpenAI requires accounts to have valid payment details on file. To add credit, visit the [OpenAI Billing Overview](https://platform.openai.com/account/billing/overview) page and purchase at least $5 in credits. Once you've added a payment method and credits, your API key should function correctly."
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- add a structured OpenAI API key validation error that exposes locale metadata
- translate API pool validation responses using the shared translator
- record current and outstanding localization work in LOCALIZATION_PROGRESS.md

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da1e7b20f0832da465a880b3a5f0d1