### PR TITLE
Add extensive i18n debugging logs

### DIFF
--- a/modules/i18n/config.py
+++ b/modules/i18n/config.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 """Helpers for building i18n components used by the moderator bot."""
 
+import logging
 from pathlib import Path
 from typing import Iterable
+
+logger = logging.getLogger(__name__)
 
 
 def _unique(paths: Iterable[Path]) -> list[Path]:
@@ -34,11 +37,20 @@ def resolve_locales_root(configured_root: str | None, repo_root: Path) -> tuple[
 
     unique_candidates = _unique(candidates)
 
+    logger.debug(
+        "Resolving locales root (configured=%s, repo_root=%s, candidates=%s)",
+        configured_root,
+        repo_root,
+        unique_candidates,
+    )
+
     for candidate in unique_candidates:
         if candidate.exists():
+            logger.debug("Locales root resolved to %s (exists=%s)", candidate, candidate.exists())
             return candidate, bool(configured_root) and candidate != raw.resolve()
 
     fallback = unique_candidates[0]
+    logger.debug("Falling back to locales root %s (configured missing=%s)", fallback, bool(configured_root))
     return fallback, bool(configured_root)
 
 

--- a/modules/i18n/guild_cache.py
+++ b/modules/i18n/guild_cache.py
@@ -65,6 +65,7 @@ class GuildLocaleCache:
     def resolve(self, candidate: Any) -> Optional[str]:
         guild_id = extract_guild_id(candidate)
         if guild_id is None:
+            logger.debug("Could not resolve guild id from candidate %r", candidate)
             return None
 
         override = self._overrides.get(guild_id)
@@ -77,6 +78,7 @@ class GuildLocaleCache:
             logger.debug("Resolved locale via stored cache (guild_id=%s): %s", guild_id, stored)
             return stored
 
+        logger.debug("No locale found for guild_id=%s", guild_id)
         return None
 
     def resolve_from_candidates(self, candidates: Iterable[Any]) -> Optional[str]:
@@ -84,6 +86,7 @@ class GuildLocaleCache:
             locale = self.resolve(candidate)
             if locale:
                 return locale
+        logger.debug("Failed to resolve locale from provided candidates")
         return None
 
     def drop(self, guild_id: int) -> None:

--- a/modules/i18n/translator.py
+++ b/modules/i18n/translator.py
@@ -57,6 +57,9 @@ class Translator:
         )
 
         for code in chain:
+            logger.debug(
+                "Attempting to resolve key '%s' from locale '%s'", key, code
+            )
             value = self._repository.get_value(code, key)
             if value is not None:
                 if code != chain[0]:


### PR DESCRIPTION
## Summary
- add detailed debug logging around locale configuration resolution and repository loading
- instrument translation service, guild cache, and translator to trace locale resolution flow
- expand locale repository logging to monitor file loading, cache hits, and key resolution

## Testing
- python -m compileall modules

------
https://chatgpt.com/codex/tasks/task_e_68da288dca80832db2d566a7aa4f4faa