### PR TITLE
Fix translator setup and shorten intimidate command descriptions

### DIFF
--- a/cogs/strikes.py
+++ b/cogs/strikes.py
@@ -339,11 +339,11 @@ class StrikesCog(commands.Cog):
     )
     @app_commands.describe(
         user=app_commands.locale_str(
-            "The user to intimidate. If not provided, the entire channel will be addressed with a broader message.",
+            "User to intimidate. Leave empty to address the whole channel.",
             key="cogs.strikes.meta.intimidate.params.user",
         ),
         channel=app_commands.locale_str(
-            "If true, sends the user warning to the channel; otherwise, sends a direct message to the user.",
+            "Send the warning in the channel instead of a direct message.",
             key="cogs.strikes.meta.intimidate.params.channel",
         )
     )

--- a/locales/en/cogs.strikes.json
+++ b/locales/en/cogs.strikes.json
@@ -41,8 +41,8 @@
         "intimidate": {
           "description": "Intimidate the channel, or a specific user.",
           "params": {
-            "user": "The user to intimidate. If not provided, the entire channel will be addressed with a broader message.",
-            "channel": "If true, sends the user warning to the channel; otherwise, sends a direct message to the user."
+            "user": "User to intimidate. Leave empty to address the whole channel.",
+            "channel": "Send the warning in the channel instead of a direct message."
           }
         }
       },


### PR DESCRIPTION
## Summary
- prepare the app command translator during initialisation and await installing it in `setup_hook`
- centralise guild locale caching so startup and guild join reuse the same helper
- shorten the intimidate command parameter descriptions to meet Discord's length limits and update the English locale text

## Testing
- pytest

------