### PR TITLE
Increase i18n warning visibility

### DIFF
--- a/modules/i18n/config.py
+++ b/modules/i18n/config.py
@@ -50,7 +50,11 @@ def resolve_locales_root(configured_root: str | None, repo_root: Path) -> tuple[
             return candidate, bool(configured_root) and candidate != raw.resolve()
 
     fallback = unique_candidates[0]
-    logger.info("Falling back to locales root %s (configured missing=%s)", fallback, bool(configured_root))
+    logger.warning(
+        "Falling back to locales root %s (configured missing=%s)",
+        fallback,
+        bool(configured_root),
+    )
     return fallback, bool(configured_root)
 
 

--- a/modules/i18n/guild_cache.py
+++ b/modules/i18n/guild_cache.py
@@ -88,7 +88,7 @@ class GuildLocaleCache:
     def resolve(self, candidate: Any) -> Optional[str]:
         guild_id = extract_guild_id(candidate)
         if guild_id is None:
-            logger.info("Could not resolve guild id from candidate %r", candidate)
+            logger.warning("Could not resolve guild id from candidate %r", candidate)
             return None
 
         override = self._overrides.get(guild_id)
@@ -101,7 +101,7 @@ class GuildLocaleCache:
             logger.info("Resolved locale via stored cache (guild_id=%s): %s", guild_id, stored)
             return stored
 
-        logger.info("No locale found for guild_id=%s", guild_id)
+        logger.warning("No locale found for guild_id=%s", guild_id)
         return None
 
     def resolve_from_candidates(self, candidates: Iterable[Any]) -> Optional[str]:
@@ -109,7 +109,7 @@ class GuildLocaleCache:
             locale = self.resolve(candidate)
             if locale:
                 return locale
-        logger.info("Failed to resolve locale from provided candidates")
+        logger.warning("Failed to resolve locale from provided candidates")
         return None
 
     def drop(self, guild_id: int) -> None:

--- a/modules/i18n/locales.py
+++ b/modules/i18n/locales.py
@@ -78,7 +78,7 @@ class LocaleRepository:
         with self._lock:
             data = self._cache.get(locale)
         if data is None:
-            logger.info("Requested locale %s missing from cache", locale)
+            logger.warning("Requested locale %s missing from cache", locale)
         return self._resolve_key(data, key)
 
     def _load_from_disk(self) -> dict[str, dict[str, Any]]:
@@ -141,7 +141,7 @@ class LocaleRepository:
             if isinstance(cursor, Mapping) and part in cursor:
                 cursor = cursor[part]
             else:
-                logger.info(
+                logger.warning(
                     "Key %s missing while traversing part %s (locale data available=%s)",
                     key,
                     part,

--- a/modules/i18n/translator.py
+++ b/modules/i18n/translator.py
@@ -67,12 +67,17 @@ class Translator:
                 return self._format_value(value, placeholders)
 
         if fallback is not None:
-            logger.info(
-                "Translation for key '%s' missing; using explicit fallback '%s'", key, fallback
+            logger.warning(
+                "Translation for key '%s' missing; using explicit fallback '%s'",
+                key,
+                fallback,
             )
             return self._apply_format(fallback, placeholders)
 
-        logger.info("Translation for key '%s' missing; falling back to key with placeholders", key)
+        logger.warning(
+            "Translation for key '%s' missing; falling back to key with placeholders",
+            key,
+        )
         return self._apply_format(key, placeholders)
 
     def get_locale_snapshot(self, locale: str) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- promote warning-level logging when translation fallbacks occur so issues surface clearly
- log missing locale cache entries and key resolution failures as warnings for easier debugging
- warn when locale configuration falls back to defaults or guild locale resolution fails

## Testing
- not run

------