### PR TITLE
Improve i18n locale fallback handling and add comprehensive tests

### DIFF
--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -7,6 +7,8 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from modules.i18n.locales import LocaleRepository
+from modules.i18n.locale_utils import build_locale_chain
+from modules.i18n.service import TranslationService
 from modules.i18n.translator import Translator
 
 def _write(locale_root: Path, relative: str, payload: dict) -> None:
@@ -43,6 +45,46 @@ def test_translator_fallback_and_formatting(tmp_path: Path) -> None:
     assert translator.translate("greeting", locale="es", placeholders={"name": "Alex"}) == "Hola Alex"
     assert translator.translate("status.ready", locale="es") == "Ready"
     assert translator.translate("missing.key", fallback="Fallback") == "Fallback"
+
+
+def test_translator_falls_back_to_base_locale_before_default(tmp_path: Path) -> None:
+    root = tmp_path / "locales"
+    _write(root, "en/messages.json", {"farewell": "Goodbye"})
+    _write(root, "es/messages.json", {"farewell": "Adiós"})
+    _write(root, "es-ES/messages.json", {"greeting": "Hola"})
+
+    repository = LocaleRepository(root, default_locale="en", fallback_locale="en")
+    repository.reload()
+
+    translator = Translator(repository)
+
+    assert translator.translate("farewell", locale="es-ES") == "Adiós"
+
+
+def test_build_locale_chain_includes_specific_aliases() -> None:
+    chain = build_locale_chain("es-ES", default_locale="en", fallback_locale="en")
+
+    assert chain == ["es-ES", "es", "en"]
+
+    chain_with_alias = build_locale_chain("es-419", default_locale="en", fallback_locale="en")
+
+    assert chain_with_alias == ["es-ES", "es-419", "es", "en"]
+
+
+def test_translation_service_end_to_end(tmp_path: Path) -> None:
+    root = tmp_path / "locales"
+    _write(root, "en/common.json", {"label": "Dashboard"})
+    _write(root, "fr/common.json", {"label": "Tableau de bord"})
+
+    repository = LocaleRepository(root, default_locale="en", fallback_locale="en")
+    repository.reload()
+
+    service = TranslationService(Translator(repository))
+
+    with service.use_locale("fr-FR"):
+        assert service.translate("label") == "Tableau de bord"
+
+    assert service.translate("label") == "Dashboard"
 
 def test_refresh_reloads_from_disk(tmp_path: Path) -> None:
     root = tmp_path / "locales"


### PR DESCRIPTION
## Summary
- centralize locale normalization and fallback chain building in the i18n utilities
- update the translator to use the shared locale chain so base language fallbacks work correctly before English
- add regression tests that exercise the new fallback chain, translation service flows, and ModeratorBot integration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da4d487520832dadff49304767880a