### PR TITLE
Fix locale resolution to honor settings overrides

### DIFF
--- a/cogs/autonomous_moderation/autonomous_moderator.py
+++ b/cogs/autonomous_moderation/autonomous_moderator.py
@@ -184,7 +184,7 @@ class AutonomousModeratorCog(commands.Cog):
             if not guild:
                 continue
 
-            guild_locale = self.bot._guild_locales.resolve(guild)
+            guild_locale = self.bot.resolve_locale(guild)
 
             # Budget notification if applicable
             if report is None and trigger_msg and status == "budget":

--- a/cogs/autonomous_moderation/helpers.py
+++ b/cogs/autonomous_moderation/helpers.py
@@ -113,7 +113,7 @@ def _translate_helper(
     placeholders: dict[str, Any] | None = None,
     fallback: str,
 ) -> str:
-    locale = bot._guild_locales.resolve(guild) if guild else None
+    locale = bot.resolve_locale(guild) if guild else None
     key = f"{HELPERS_BASE}.{suffix}" if suffix else HELPERS_BASE
     return bot.translate(
         key,

--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -217,7 +217,7 @@ class Settings(commands.Cog):
 
         avatar = interaction.client.user.display_avatar.url if interaction.client.user else None
 
-        locale = self.bot._guild_locales.resolve(interaction)
+        locale = self.bot.resolve_locale(interaction)
         translator = self.bot.translator
         if locale:
             locale_display = f"`{locale}`"

--- a/modules/i18n/guild_cache.py
+++ b/modules/i18n/guild_cache.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Helpers for resolving guild locales from stored metadata."""
 
 import logging
-from typing import Any, Dict, Iterable, Mapping, Optional
+from typing import Any, Dict, Mapping, Optional
 
 from .locale_utils import normalise_locale
 
@@ -81,31 +81,6 @@ class GuildLocaleCache:
 
     def get_override(self, guild_id: int) -> Optional[str]:
         return self._overrides.get(guild_id)
-
-    def resolve(self, candidate: Any) -> Optional[str]:
-        guild_id = extract_guild_id(candidate)
-        if guild_id is None:
-            return None
-
-        override = self._overrides.get(guild_id)
-        if override:
-            logger.info("Resolved locale via override (guild_id=%s): %s", guild_id, override)
-            return override
-
-        stored = self._stored.get(guild_id)
-        if stored:
-            logger.info("Resolved locale via stored cache (guild_id=%s): %s", guild_id, stored)
-            return stored
-
-        logger.warning("No locale found for guild_id=%s", guild_id)
-        return None
-
-    def resolve_from_candidates(self, candidates: Iterable[Any]) -> Optional[str]:
-        for candidate in candidates:
-            locale = self.resolve(candidate)
-            if locale:
-                return locale
-        return None
 
     def drop(self, guild_id: int) -> None:
         self._stored.pop(guild_id, None)

--- a/modules/i18n/resolution.py
+++ b/modules/i18n/resolution.py
@@ -1,0 +1,123 @@
+"""Helpers for inferring locales from Discord events and cached overrides."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+from .guild_cache import GuildLocaleCache, extract_guild_id
+from .locale_utils import normalise_locale
+
+
+@dataclass(slots=True)
+class LocaleResolution:
+    """Represents the sources considered when resolving a locale."""
+
+    override: str | None = None
+    stored: str | None = None
+    detected: str | None = None
+
+    def resolved(self) -> str | None:
+        """Return the preferred locale using override → stored → detected priority."""
+
+        if self.override:
+            return self.override
+        if self.stored:
+            return self.stored
+        if self.detected:
+            return self.detected
+        return None
+
+    def source(self) -> str | None:
+        """Return the label describing where :meth:`resolved` originated."""
+
+        if self.override:
+            return "override"
+        if self.stored:
+            return "stored"
+        if self.detected:
+            return "detected"
+        return None
+
+
+def _detect_from_mapping(mapping: Mapping[str, Any]) -> str | None:
+    for key in ("locale", "guild_locale", "user_locale", "preferred_locale"):
+        if key in mapping:
+            candidate = normalise_locale(mapping[key])
+            if candidate:
+                return candidate
+
+    guild = mapping.get("guild")
+    if guild is not None:
+        nested = detect_locale(guild)
+        if nested:
+            return nested
+
+    return None
+
+
+def detect_locale(candidate: Any) -> str | None:
+    """Extract a locale hint from *candidate* if one is present."""
+
+    if candidate is None:
+        return None
+
+    if isinstance(candidate, Mapping):
+        return _detect_from_mapping(candidate)
+
+    for attribute in ("locale", "guild_locale", "user_locale", "preferred_locale"):
+        value = getattr(candidate, attribute, None)
+        detected = normalise_locale(value)
+        if detected:
+            return detected
+
+    guild = getattr(candidate, "guild", None)
+    if guild is not None and guild is not candidate:
+        nested = detect_locale(guild)
+        if nested:
+            return nested
+
+    return None
+
+
+class LocaleResolver:
+    """Resolve locales using configured overrides and automatic detection."""
+
+    def __init__(self, cache: GuildLocaleCache) -> None:
+        self._cache = cache
+
+    def infer(self, *candidates: Any) -> LocaleResolution:
+        return self.infer_from_iterable(candidates)
+
+    def infer_from_iterable(self, candidates: Iterable[Any]) -> LocaleResolution:
+        resolution = LocaleResolution()
+
+        for candidate in candidates:
+            if candidate is None:
+                continue
+
+            guild_id = extract_guild_id(candidate)
+            if guild_id is not None:
+                if resolution.override is None:
+                    resolution.override = self._cache.get_override(guild_id)
+                if resolution.stored is None:
+                    resolution.stored = self._cache.get(guild_id)
+
+                if resolution.override:
+                    detected = detect_locale(candidate)
+                    if resolution.detected is None and detected:
+                        resolution.detected = detected
+                    break
+
+            if resolution.detected is None:
+                detected = detect_locale(candidate)
+                if detected:
+                    resolution.detected = detected
+
+        return resolution
+
+
+__all__ = [
+    "LocaleResolution",
+    "LocaleResolver",
+    "detect_locale",
+]


### PR DESCRIPTION
## Summary
- add a dedicated locale resolver that prioritises stored overrides before fallbacks
- update ModeratorBot and guild helpers to use the new resolver instead of ad-hoc logic
- expand locale tests to cover override precedence, detection, and stored fallbacks

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68da52ca1b64832dac7e909186455c27