### PR TITLE
Fix locale override precedence and add Spanish translation tests

### DIFF
--- a/modules/core/moderator_bot.py
+++ b/modules/core/moderator_bot.py
@@ -305,8 +305,19 @@ class ModeratorBot(commands.Bot):
             _logger.warning(
                 "Loaded locale override for guild %s: %r", guild_id, override
             )
-            self._guild_locales.set_override(guild_id, override)
-            return
+            normalized = self._guild_locales.set_override(guild_id, override)
+            if normalized:
+                _logger.debug(
+                    "Using saved override for guild %s -> %s", guild_id, normalized
+                )
+                return
+
+            _logger.warning(
+                "Stored override for guild %s (%r) is not a supported locale; "
+                "falling back to guild preference",
+                guild_id,
+                override,
+            )
 
         try:
             fallback = await mysql.get_guild_locale(guild_id)

--- a/modules/i18n/resolution.py
+++ b/modules/i18n/resolution.py
@@ -95,25 +95,35 @@ class LocaleResolver:
             if candidate is None:
                 continue
 
-            guild_id = extract_guild_id(candidate)
-            if guild_id is not None:
-                if resolution.override is None:
-                    resolution.override = self._cache.get_override(guild_id)
-                if resolution.stored is None:
-                    resolution.stored = self._cache.get(guild_id)
+            self._apply_guild_locale_overrides(candidate, resolution)
+            self._apply_detected_locale(candidate, resolution)
 
-                if resolution.override:
-                    detected = detect_locale(candidate)
-                    if resolution.detected is None and detected:
-                        resolution.detected = detected
-                    break
-
-            if resolution.detected is None:
-                detected = detect_locale(candidate)
-                if detected:
-                    resolution.detected = detected
+            if resolution.override and resolution.detected:
+                break
 
         return resolution
+
+    def _apply_guild_locale_overrides(
+        self, candidate: Any, resolution: LocaleResolution
+    ) -> bool:
+        guild_id = extract_guild_id(candidate)
+        if guild_id is None:
+            return False
+
+        if resolution.override is None:
+            resolution.override = self._cache.get_override(guild_id)
+        if resolution.stored is None:
+            resolution.stored = self._cache.get(guild_id)
+
+        return bool(resolution.override)
+
+    def _apply_detected_locale(self, candidate: Any, resolution: LocaleResolution) -> None:
+        if resolution.detected is not None:
+            return
+
+        detected = detect_locale(candidate)
+        if detected:
+            resolution.detected = detected
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- ignore unsupported saved locale overrides so guild preferences and detection can fall back correctly
- refactor the locale resolver to clearly separate override caching from detection logic while preserving override priority
- add regression tests covering Spanish overrides, alias normalization, and fallback behaviour for translated help text

## Testing
- pytest tests/test_moderator_bot_locale.py

------