### PR TITLE
Localize captcha messaging and action choice labels

### DIFF
--- a/LOCALIZATION_PROGRESS.md
+++ b/LOCALIZATION_PROGRESS.md
@@ -17,11 +17,10 @@
 - [x] cogs/debug.py — Localized command metadata and locale summary message.
 - [x] cogs/autonomous_moderation/auto_commands.py — Localized command metadata, choice labels, and mode status output.
 - [x] cogs/voice_moderation/voice_moderator.py — Localized transcript embeds and budget notifications.
+- [x] modules/utils/actions.py — Localized moderation action choices using locale-backed labels.
+- [x] cogs/captcha/base.py — Localized captcha embed scaffolding, duration text, and default button labels.
+- [x] cogs/captcha/delivery.py — Localized DM prompts, embed helpers, and verification call-to-action labels.
+- [x] cogs/captcha/embed.py — Localized verification embed title, body copy, footer, and button label.
 
 ## To Do
-- [ ] modules/utils/actions.py — Choice labels produced for moderation actions remain hard-coded.
-- [ ] cogs/captcha/base.py — Captcha embeds and button labels still contain inline English strings.
-- [ ] cogs/captcha/delivery.py — Help text and verification prompts need localization.
-- [ ] cogs/captcha/embed.py — Verification embed titles and descriptions remain hard-coded.
-- [ ] Review remaining modules for embedded message strings and prompts.
-- [ ] Expand audit to remaining modules for embedded message strings and prompts.
+- [ ] Audit remaining modules for embedded message strings and prompts.

--- a/locales/en-US/cogs.captcha.json
+++ b/locales/en-US/cogs.captcha.json
@@ -39,6 +39,63 @@
       },
       "timeout": {
         "failure_reason": "Captcha verification timed out."
+      },
+      "base": {
+        "duration": {
+          "few_minutes": "a few minutes",
+          "joiner": ", ",
+          "seconds": {
+            "one": "{count} second",
+            "other": "{count} seconds"
+          },
+          "minutes": {
+            "one": "{count} minute",
+            "other": "{count} minutes"
+          },
+          "hours": {
+            "one": "{count} hour",
+            "other": "{count} hours"
+          },
+          "days": {
+            "one": "{count} day",
+            "other": "{count} days"
+          }
+        },
+        "description": {
+          "greeting": "Hi {member}! To finish joining **{guild}**, ",
+          "grace": "please {instruction} within **{grace}**.",
+          "no_grace": "please {instruction} when you're ready.",
+          "instruction_default": "complete the captcha",
+          "attempts": {
+            "one": " You have **{count}** attempt.",
+            "other": " You have **{count}** attempts."
+          }
+        },
+        "embed": {
+          "title": "Captcha Verification Required",
+          "footer": "Powered by Moderator Bot"
+        },
+        "button": {
+          "label": "Verify now"
+        }
+      },
+      "delivery": {
+        "dm": {
+          "button_label": "Click here to verify"
+        },
+        "embed": {
+          "location": "visit {channel} and complete the captcha",
+          "help_title": "Need help?",
+          "help_value": "Click the button below to open the verification page.",
+          "button_label": "Open verification page"
+        }
+      },
+      "embed_message": {
+        "description": "Click the button below to verify yourself. Once you pass the captcha, you will gain access to the rest of the server.",
+        "login_notice": "You may be asked to log in to the Moderator Bot dashboard first.",
+        "title": "Complete Captcha Verification",
+        "footer": "Guild ID: {guild_id} | Powered by Moderator Bot",
+        "button_label": "Verify now"
       }
     }
   }

--- a/locales/en-US/modules.utils.actions.json
+++ b/locales/en-US/modules.utils.actions.json
@@ -1,0 +1,20 @@
+{
+  "modules": {
+    "utils": {
+      "actions": {
+        "choices": {
+          "strike": "Strike",
+          "kick": "Kick",
+          "ban": "Ban",
+          "timeout": "Timeout",
+          "delete": "Delete Message",
+          "give_role": "Give Role",
+          "take_role": "Remove Role",
+          "warn": "Warn User",
+          "broadcast": "Broadcast Message",
+          "auto": "Auto"
+        }
+      }
+    }
+  }
+}

--- a/locales/en/cogs.captcha.json
+++ b/locales/en/cogs.captcha.json
@@ -39,6 +39,63 @@
       },
       "timeout": {
         "failure_reason": "Captcha verification timed out."
+      },
+      "base": {
+        "duration": {
+          "few_minutes": "a few minutes",
+          "joiner": ", ",
+          "seconds": {
+            "one": "{count} second",
+            "other": "{count} seconds"
+          },
+          "minutes": {
+            "one": "{count} minute",
+            "other": "{count} minutes"
+          },
+          "hours": {
+            "one": "{count} hour",
+            "other": "{count} hours"
+          },
+          "days": {
+            "one": "{count} day",
+            "other": "{count} days"
+          }
+        },
+        "description": {
+          "greeting": "Hi {member}! To finish joining **{guild}**, ",
+          "grace": "please {instruction} within **{grace}**.",
+          "no_grace": "please {instruction} when you're ready.",
+          "instruction_default": "complete the captcha",
+          "attempts": {
+            "one": " You have **{count}** attempt.",
+            "other": " You have **{count}** attempts."
+          }
+        },
+        "embed": {
+          "title": "Captcha Verification Required",
+          "footer": "Powered by Moderator Bot"
+        },
+        "button": {
+          "label": "Verify now"
+        }
+      },
+      "delivery": {
+        "dm": {
+          "button_label": "Click here to verify"
+        },
+        "embed": {
+          "location": "visit {channel} and complete the captcha",
+          "help_title": "Need help?",
+          "help_value": "Click the button below to open the verification page.",
+          "button_label": "Open verification page"
+        }
+      },
+      "embed_message": {
+        "description": "Click the button below to verify yourself. Once you pass the captcha, you will gain access to the rest of the server.",
+        "login_notice": "You may be asked to log in to the Moderator Bot dashboard first.",
+        "title": "Complete Captcha Verification",
+        "footer": "Guild ID: {guild_id} | Powered by Moderator Bot",
+        "button_label": "Verify now"
       }
     }
   }

--- a/locales/en/modules.utils.actions.json
+++ b/locales/en/modules.utils.actions.json
@@ -1,0 +1,20 @@
+{
+  "modules": {
+    "utils": {
+      "actions": {
+        "choices": {
+          "strike": "Strike",
+          "kick": "Kick",
+          "ban": "Ban",
+          "timeout": "Timeout",
+          "delete": "Delete Message",
+          "give_role": "Give Role",
+          "take_role": "Remove Role",
+          "warn": "Warn User",
+          "broadcast": "Broadcast Message",
+          "auto": "Auto"
+        }
+      }
+    }
+  }
+}

--- a/modules/utils/actions.py
+++ b/modules/utils/actions.py
@@ -1,16 +1,24 @@
 from typing import Iterable, Optional, Union
 from discord import app_commands
 
+
+def _choice_label(fallback: str, value: str) -> app_commands.locale_str:
+    return app_commands.locale_str(
+        fallback,
+        key=f"modules.utils.actions.choices.{value}",
+    )
+
+
 ACTIONS = [
-    ("Strike", "strike"),
-    ("Kick", "kick"),
-    ("Ban", "ban"),
-    ("Timeout", "timeout"),
-    ("Delete Message", "delete"),
-    ("Give Role", "give_role"),
-    ("Remove Role", "take_role"),
-    ("Warn User", "warn"),
-    ("Broadcast Message", "broadcast")
+    (_choice_label("Strike", "strike"), "strike"),
+    (_choice_label("Kick", "kick"), "kick"),
+    (_choice_label("Ban", "ban"), "ban"),
+    (_choice_label("Timeout", "timeout"), "timeout"),
+    (_choice_label("Delete Message", "delete"), "delete"),
+    (_choice_label("Give Role", "give_role"), "give_role"),
+    (_choice_label("Remove Role", "take_role"), "take_role"),
+    (_choice_label("Warn User", "warn"), "warn"),
+    (_choice_label("Broadcast Message", "broadcast"), "broadcast"),
 ]
 
 VALID_ACTION_VALUES = [a[1] for a in ACTIONS]
@@ -26,9 +34,10 @@ def action_choices(
     if include:
         for item in include:
             if isinstance(item, str):
-                base.append((item.capitalize(), item))
+                base.append((_choice_label(item.capitalize(), item), item))
             else:
-                base.append(item)
+                label, value = item
+                base.append((_choice_label(label, value), value))
 
     seen = set()
     final = []


### PR DESCRIPTION
## Summary
- localize moderation action choices through locale-backed `app_commands` strings
- move captcha embed, DM, and button text into locale dictionaries and reuse translator helpers
- record the completed captcha localization work in `LOCALIZATION_PROGRESS.md`

## Testing
- python -m compileall modules cogs

------