### PR TITLE
Localize event manager responses

### DIFF
--- a/LOCALIZATION_PROGRESS.md
+++ b/LOCALIZATION_PROGRESS.md
@@ -29,6 +29,7 @@
 - [x] modules/utils/mysql/settings.py — Localized premium requirement enforcement messaging.
 - [x] modules/variables/TimeString.py — Localized invalid duration validation error.
 - [x] modules/utils/localization.py — Added reusable localized error helper for validation feedback.
+- [x] modules/utils/event_manager.py — Localized adaptive event manager responses for action assignments.
 
 ## To Do
 - [ ] Audit remaining modules for embedded message strings and prompts.

--- a/locales/en-US/modules.utils.event_manager.json
+++ b/locales/en-US/modules.utils.event_manager.json
@@ -1,0 +1,19 @@
+{
+  "modules": {
+    "utils": {
+      "event_manager": {
+        "add": {
+          "duplicate": "`{action}` is already set for `{event}`.",
+          "success": "Added `{action}` to `{event}`."
+        },
+        "remove": {
+          "missing": "`{action}` is not set for `{event}`.",
+          "success": "Removed `{action}` from `{event}`."
+        },
+        "clear": {
+          "success": "All adaptive events have been cleared."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add locale-backed strings for adaptive event manager responses under en-US
- record the localization coverage for modules/utils/event_manager.py in the progress tracker

## Testing
- not run (not required)


------