### PR TITLE
Localize captcha processor user-facing strings

### DIFF
--- a/LOCALIZATION_PROGRESS.md
+++ b/LOCALIZATION_PROGRESS.md
@@ -36,6 +36,7 @@
 - [x] modules/nsfw_scanner/helpers/videos.py — Replaced hard-coded scan reasons with locale-driven identifiers.
 - [x] modules/nsfw_scanner/helpers/images.py — Localized similarity-match reasons for scan summaries.
 - [x] modules/nsfw_scanner/helpers/moderation.py — Localized OpenAI moderation reason codes for verbose reporting.
+- [x] modules/captcha/processor.py — Localized captcha callback errors, success/failure embeds, and deferred action notes.
 
 ## To Do
 - [ ] Audit remaining modules for embedded message strings and prompts.

--- a/locales/en/modules.captcha.processor.json
+++ b/locales/en/modules.captcha.processor.json
@@ -1,0 +1,63 @@
+{
+  "modules": {
+    "captcha": {
+      "processor": {
+        "success": {
+          "reason": "Captcha verification successful",
+          "embed": {
+            "title": "Captcha Verification Passed",
+            "description": "{mention} ({user_id}) passed captcha verification.",
+            "fields": {
+              "actions": "Actions Applied",
+              "attempts": "Attempts",
+              "provider": "Provider",
+              "challenge": "Challenge",
+              "review": "Review"
+            }
+          }
+        },
+        "failure": {
+          "reason_default": "Failed captcha verification.",
+          "notes": {
+            "deferred_generic": "Failure actions deferred; captcha attempts remain.",
+            "deferred_remaining": "Failure actions deferred; {remaining} {attempts_word} remaining.",
+            "member_left": "Member is no longer in the guild; configured failure actions were skipped."
+          },
+          "attempts": {
+            "unlimited": "Unlimited attempts remain.",
+            "additional": "Additional attempts remain.",
+            "remaining": "{count} {attempts_word} remaining.",
+            "word_one": "attempt",
+            "word_other": "attempts"
+          },
+          "embed": {
+            "title_failed": "Captcha Verification Failed",
+            "title_attempt": "Captcha Attempt Failed",
+            "description_failed": "{mention} ({user_id}) failed captcha verification.",
+            "description_attempt": "{mention} ({user_id}) failed a captcha attempt.",
+            "fields": {
+              "actions": "Actions Applied",
+              "notes": "Notes",
+              "attempts": "Attempts",
+              "remaining": "Attempts Remaining",
+              "challenge": "Challenge",
+              "reason": "Reason",
+              "review": "Review"
+            }
+          }
+        },
+        "errors": {
+          "role_assignment_failed": "Failed to apply captcha success actions due to a Discord API error.",
+          "unknown_token": "No pending captcha verification found for this user.",
+          "token_mismatch": "Captcha token does not match the pending verification.",
+          "missing_permissions": "Bot is missing permissions to apply captcha failure actions.",
+          "action_failed": "Failed to apply captcha failure actions due to a Discord API error.",
+          "guild_not_found": "Guild {guild_id} is not available to this bot.",
+          "guild_fetch_failed": "Failed to fetch guild {guild_id} from Discord.",
+          "member_not_found": "Member {user_id} not found in guild {guild_id}.",
+          "member_fetch_failed": "Failed to fetch member {user_id} from guild {guild_id}."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add translation helpers to the captcha processor so errors, embeds, and prompts pull from locale data instead of hard-coded strings
- provide English locale entries for captcha callback success, failure, and error messaging
- log the captcha processor work in the localization progress tracker

## Testing
- python -m compileall modules/captcha/processor.py

------