### PR TITLE
Localize remaining command metadata strings

### DIFF
--- a/LOCALIZATION_PROGRESS.md
+++ b/LOCALIZATION_PROGRESS.md
@@ -37,6 +37,9 @@
 - [x] modules/nsfw_scanner/helpers/images.py — Localized similarity-match reasons for scan summaries.
 - [x] modules/nsfw_scanner/helpers/moderation.py — Localized OpenAI moderation reason codes for verbose reporting.
 - [x] modules/captcha/processor.py — Localized captcha callback errors, success/failure embeds, and deferred action notes.
+- [x] cogs/api_pool.py — Localized slash command group metadata for API pool management.
+- [x] cogs/banned_urls.py — Localized action management command metadata and parameter prompts.
+- [x] cogs/settings.py — Localized help command metadata and command option prompt.
 
 ## To Do
 - [ ] Audit remaining modules for embedded message strings and prompts.

--- a/cogs/api_pool.py
+++ b/cogs/api_pool.py
@@ -26,12 +26,18 @@ class ApiPoolCog(commands.Cog):
 
     api_pool_group = app_commands.Group(
         name="api_pool",
-        description="Management of your personal API keys in the pool.",
+        description=app_commands.locale_str(
+            "Management of your personal API keys in the pool.",
+            key="cogs.api_pool.meta.group_description",
+        ),
     )
 
     @api_pool_group.command(
         name="explanation",
-        description="Explain the API pool."
+        description=app_commands.locale_str(
+            "Explain the API pool.",
+            key="cogs.api_pool.meta.explanation.description",
+        )
     )
     async def explain(self, interaction: Interaction):
         guild_id = interaction.guild.id
@@ -43,7 +49,10 @@ class ApiPoolCog(commands.Cog):
 
     @api_pool_group.command(
         name="add",
-        description="Add an API key to the pool."
+        description=app_commands.locale_str(
+            "Add an API key to the pool.",
+            key="cogs.api_pool.meta.add.description",
+        )
     )
     async def add_api(self, interaction: Interaction, api_key: str):
         await interaction.response.defer(ephemeral=True)
@@ -102,7 +111,10 @@ class ApiPoolCog(commands.Cog):
 
     @api_pool_group.command(
         name="remove",
-        description="Remove an API key from the pool."
+        description=app_commands.locale_str(
+            "Remove an API key from the pool.",
+            key="cogs.api_pool.meta.remove.description",
+        )
     )
     async def remove_api(self, interaction: Interaction, api_key: str):
         user_id = interaction.user.id
@@ -124,7 +136,10 @@ class ApiPoolCog(commands.Cog):
 
     @api_pool_group.command(
         name="clear",
-        description="Clear all your API keys from the pool."
+        description=app_commands.locale_str(
+            "Clear all your API keys from the pool.",
+            key="cogs.api_pool.meta.clear.description",
+        )
     )
     async def clear_api(self, interaction: Interaction):
         user_id = interaction.user.id
@@ -146,7 +161,10 @@ class ApiPoolCog(commands.Cog):
 
     @api_pool_group.command(
         name="list",
-        description="List all API keys in your pool (encrypted)."
+        description=app_commands.locale_str(
+            "List all API keys in your pool (encrypted).",
+            key="cogs.api_pool.meta.list.description",
+        )
     )
     async def list_apis(self, interaction: Interaction):
         user_id = interaction.user.id

--- a/cogs/banned_urls.py
+++ b/cogs/banned_urls.py
@@ -262,8 +262,23 @@ class BannedURLsCog(commands.Cog):
     async def handle_message_edit(self, cached_before: dict, after: discord.Message):
         await self.handle_message(after)
 
-    @bannedurls_group.command(name="add_action", description="Add a moderation action to be triggered when a banned URL is detected.")
-    @app_commands.describe(action="Action to perform", duration="Only required for timeout (e.g. 10m, 1h, 3d)")
+    @bannedurls_group.command(
+        name="add_action",
+        description=app_commands.locale_str(
+            "Add a moderation action to be triggered when a banned URL is detected.",
+            key="cogs.banned_urls.meta.add_action.description",
+        ),
+    )
+    @app_commands.describe(
+        action=app_commands.locale_str(
+            "Action to perform",
+            key="cogs.banned_urls.meta.add_action.params.action",
+        ),
+        duration=app_commands.locale_str(
+            "Only required for timeout (e.g. 10m, 1h, 3d)",
+            key="cogs.banned_urls.meta.add_action.params.duration",
+        ),
+    )
     @app_commands.choices(action=action_choices())
     async def add_banned_action(self, interaction: Interaction, action: str, duration: str = None, role: discord.Role = None, reason: str = None):
         await interaction.response.defer(ephemeral=True)
@@ -273,14 +288,31 @@ class BannedURLsCog(commands.Cog):
         msg = await manager.add_action(interaction.guild.id, action_str, translator=self.bot.translate)
         await interaction.followup.send(msg, ephemeral=True)
 
-    @bannedurls_group.command(name="remove_action", description="Remove a specific action from the list of punishments for banned URLs.")
-    @app_commands.describe(action="Exact action string to remove (e.g. timeout, delete)")
+    @bannedurls_group.command(
+        name="remove_action",
+        description=app_commands.locale_str(
+            "Remove a specific action from the list of punishments for banned URLs.",
+            key="cogs.banned_urls.meta.remove_action.description",
+        ),
+    )
+    @app_commands.describe(
+        action=app_commands.locale_str(
+            "Exact action string to remove (e.g. timeout, delete)",
+            key="cogs.banned_urls.meta.remove_action.params.action",
+        )
+    )
     @app_commands.autocomplete(action=manager.autocomplete)
     async def remove_banned_action(self, interaction: Interaction, action: str):
         msg = await manager.remove_action(interaction.guild.id, action, translator=self.bot.translate)
         await interaction.response.send_message(msg, ephemeral=True)
 
-    @bannedurls_group.command(name="view_actions", description="Show all actions currently configured to trigger when banned URLs are used.")
+    @bannedurls_group.command(
+        name="view_actions",
+        description=app_commands.locale_str(
+            "Show all actions currently configured to trigger when banned URLs are used.",
+            key="cogs.banned_urls.meta.view_actions.description",
+        ),
+    )
     async def view_banned_actions(self, interaction: Interaction):
         guild_id = interaction.guild.id
         actions = await manager.view_actions(interaction.guild.id)

--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -251,8 +251,19 @@ class Settings(commands.Cog):
             chunks.append(buf)
         return chunks
 
-    @app_commands.command(name="help", description="Get help on a specific command group.")
-    @app_commands.describe(command="Optional: command group to get help with")
+    @app_commands.command(
+        name="help",
+        description=app_commands.locale_str(
+            "Get help on a specific command group.",
+            key="cogs.settings.meta.help.description",
+        ),
+    )
+    @app_commands.describe(
+        command=app_commands.locale_str(
+            "Optional: command group to get help with",
+            key="cogs.settings.meta.help.params.command",
+        )
+    )
     @app_commands.default_permissions(moderate_members=True)
     async def help(self, interaction: Interaction, command: Optional[str] = None):
         await interaction.response.defer(ephemeral=True)

--- a/locales/en-US/cogs.api_pool.json
+++ b/locales/en-US/cogs.api_pool.json
@@ -1,6 +1,24 @@
 ﻿{
   "cogs": {
     "api_pool": {
+      "meta": {
+        "group_description": "Management of your personal API keys in the pool.",
+        "explanation": {
+          "description": "Explain the API pool."
+        },
+        "add": {
+          "description": "Add an API key to the pool."
+        },
+        "remove": {
+          "description": "Remove an API key from the pool."
+        },
+        "clear": {
+          "description": "Clear all your API keys from the pool."
+        },
+        "list": {
+          "description": "List all API keys in your pool (encrypted)."
+        }
+      },
       "explanation": {
         "body": "**What is the API Pool?**\nThe API Pool is a secure and anonymous collection of shared OpenAI API keys. It enables Moderator Bot to continue operating effectively, even when individual users face rate limits.\n\n**How does it work?**\n- When you add your OpenAI API key to the pool, it's encrypted and stored securely.\n- The bot uses these keys exclusively for accessing OpenAI models to perform moderation tasks.\n- Your API key remains confidential; no one, including the bot developers, can view it.\n- You have full control and can remove your API key from the pool at any time.\n\n**Important:** To contribute your API key, your OpenAI account must have at least $5 in prepaid credits. Even though the moderation endpoint is free to use, OpenAI requires accounts to have active billing details and quota. You can add credit to your account here: <https://platform.openai.com/account/billing/overview>\n\nBy contributing your API key, you help ensure that Moderator Bot remains responsive and effective for all users."
       },

--- a/locales/en-US/cogs.banned_urls.json
+++ b/locales/en-US/cogs.banned_urls.json
@@ -14,6 +14,22 @@
         },
         "clear": {
           "description": "Clear all banned URLs."
+        },
+        "add_action": {
+          "description": "Add a moderation action to be triggered when a banned URL is detected.",
+          "params": {
+            "action": "Action to perform",
+            "duration": "Only required for timeout (e.g. 10m, 1h, 3d)"
+          }
+        },
+        "remove_action": {
+          "description": "Remove a specific action from the list of punishments for banned URLs.",
+          "params": {
+            "action": "Exact action string to remove (e.g. timeout, delete)"
+          }
+        },
+        "view_actions": {
+          "description": "Show all actions currently configured to trigger when banned URLs are used."
         }
       },
       "limit_reached": "You've reached the limit of {limit} banned URLs for this server.\nUse `/bannedurls remove` or `/bannedurls clear` to make space.",

--- a/locales/en-US/cogs.settings.json
+++ b/locales/en-US/cogs.settings.json
@@ -4,7 +4,10 @@
       "meta": {
         "group_description": "Manage server settings.",
         "help": {
-          "description": "Get help on settings."
+          "description": "Get help on a specific command group.",
+          "params": {
+            "command": "Optional: command group to get help with"
+          }
         },
         "reset": {
           "description": "Wipe all settings and start with defaults. This can't be undone"

--- a/locales/en/cogs.api_pool.json
+++ b/locales/en/cogs.api_pool.json
@@ -1,6 +1,24 @@
 ﻿{
   "cogs": {
     "api_pool": {
+      "meta": {
+        "group_description": "Management of your personal API keys in the pool.",
+        "explanation": {
+          "description": "Explain the API pool."
+        },
+        "add": {
+          "description": "Add an API key to the pool."
+        },
+        "remove": {
+          "description": "Remove an API key from the pool."
+        },
+        "clear": {
+          "description": "Clear all your API keys from the pool."
+        },
+        "list": {
+          "description": "List all API keys in your pool (encrypted)."
+        }
+      },
       "explanation": {
         "body": "**What is the API Pool?**\nThe API Pool is a secure and anonymous collection of shared OpenAI API keys. It enables Moderator Bot to continue operating effectively, even when individual users face rate limits.\n\n**How does it work?**\n- When you add your OpenAI API key to the pool, it's encrypted and stored securely.\n- The bot uses these keys exclusively for accessing OpenAI models to perform moderation tasks.\n- Your API key remains confidential; no one, including the bot developers, can view it.\n- You have full control and can remove your API key from the pool at any time.\n\n**Important:** To contribute your API key, your OpenAI account must have at least $5 in prepaid credits. Even though the moderation endpoint is free to use, OpenAI requires accounts to have active billing details and quota. You can add credit to your account here: <https://platform.openai.com/account/billing/overview>\n\nBy contributing your API key, you help ensure that Moderator Bot remains responsive and effective for all users."
       },

--- a/locales/en/cogs.banned_urls.json
+++ b/locales/en/cogs.banned_urls.json
@@ -14,6 +14,22 @@
         },
         "clear": {
           "description": "Clear all banned URLs."
+        },
+        "add_action": {
+          "description": "Add a moderation action to be triggered when a banned URL is detected.",
+          "params": {
+            "action": "Action to perform",
+            "duration": "Only required for timeout (e.g. 10m, 1h, 3d)"
+          }
+        },
+        "remove_action": {
+          "description": "Remove a specific action from the list of punishments for banned URLs.",
+          "params": {
+            "action": "Exact action string to remove (e.g. timeout, delete)"
+          }
+        },
+        "view_actions": {
+          "description": "Show all actions currently configured to trigger when banned URLs are used."
         }
       },
       "limit_reached": "You've reached the limit of {limit} banned URLs for this server.\nUse `/bannedurls remove` or `/bannedurls clear` to make space.",

--- a/locales/en/cogs.settings.json
+++ b/locales/en/cogs.settings.json
@@ -4,7 +4,10 @@
       "meta": {
         "group_description": "Manage server settings.",
         "help": {
-          "description": "Get help on settings."
+          "description": "Get help on a specific command group.",
+          "params": {
+            "command": "Optional: command group to get help with"
+          }
         },
         "reset": {
           "description": "Wipe all settings and start with defaults. This can't be undone"


### PR DESCRIPTION
## Summary
- add locale-backed descriptions for API pool, banned URL action management, and settings help commands
- document the localization progress for the newly covered files
- extend English locale files with metadata and parameter text for the updated commands

## Testing
- python -m compileall cogs/api_pool.py cogs/banned_urls.py cogs/settings.py

------
https://chatgpt.com/codex/tasks/task_e_68db77edcb1c832da2e0d91837facbab