### PR TITLE
Localize NSFW scan file type labels

### DIFF
--- a/LOCALIZATION_PROGRESS.md
+++ b/LOCALIZATION_PROGRESS.md
@@ -36,6 +36,7 @@
 - [x] modules/nsfw_scanner/helpers/videos.py — Replaced hard-coded scan reasons with locale-driven identifiers.
 - [x] modules/nsfw_scanner/helpers/images.py — Localized similarity-match reasons for scan summaries.
 - [x] modules/nsfw_scanner/helpers/moderation.py — Localized OpenAI moderation reason codes for verbose reporting.
+- [x] modules/nsfw_scanner/utils.py — Localized file type labels for verbose scan reporting embeds.
 - [x] modules/captcha/processor.py — Localized captcha callback errors, success/failure embeds, and deferred action notes.
 
 ## To Do

--- a/locales/en/modules.nsfw_scanner.json
+++ b/locales/en/modules.nsfw_scanner.json
@@ -18,6 +18,11 @@
               "type": "Type: `{file_type}`",
               "decision": "Decision: **{decision}**"
             },
+            "file_types": {
+              "image": "Image",
+              "video": "Video",
+              "unknown": "Unknown"
+            },
             "decision": {
               "nsfw": "NSFW",
               "safe": "Safe",


### PR DESCRIPTION
## Summary
- return canonical file type identifiers from the NSFW scanner utilities so they can be localized consistently
- translate the verbose scan report type field using new locale entries for image, video, and unknown content labels
- document the completed localization work for `modules/nsfw_scanner/utils.py` in the localization progress tracker

## Testing
- python -m compileall modules/nsfw_scanner

------