### PR TITLE
Localize banned URL action commands and settings help prompts

### DIFF
--- a/LOCALIZATION_PROGRESS.md
+++ b/LOCALIZATION_PROGRESS.md
@@ -8,13 +8,13 @@
 - [x] cogs/banned_words.py — Localized command descriptions, parameter prompts, and action choices.
 - [x] cogs/strikes.py — Localized command metadata and parameter descriptions for moderation utilities.
 - [x] cogs/channel_config.py — Localized channel configuration metadata and translated choice labels.
-- [x] cogs/settings.py — Localized group metadata and command descriptions.
+- [x] cogs/settings.py — Localized group metadata and command descriptions (including help command metadata).
 - [x] cogs/settings.py — Localized help overview embeds, dashboard prompts, and group listings.
 - [x] cogs/dashboard.py — Moved slash command description into locale files.
 - [x] cogs/scam_detection.py — Localized command metadata, parameter prompts, and link-checking responses.
 - [x] cogs/monitoring.py — Localized command metadata, choice labels, and empty-content placeholders.
 - [x] cogs/captcha/cog.py — Localized slash command metadata.
-- [x] cogs/banned_urls.py — Localized command metadata.
+- [x] cogs/banned_urls.py — Localized command metadata and action management prompts.
 - [x] cogs/debug.py — Localized command metadata and locale summary message.
 - [x] cogs/autonomous_moderation/auto_commands.py — Localized command metadata, choice labels, and mode status output.
 - [x] cogs/voice_moderation/voice_moderator.py — Localized transcript embeds and budget notifications.

--- a/cogs/banned_urls.py
+++ b/cogs/banned_urls.py
@@ -262,8 +262,23 @@ class BannedURLsCog(commands.Cog):
     async def handle_message_edit(self, cached_before: dict, after: discord.Message):
         await self.handle_message(after)
 
-    @bannedurls_group.command(name="add_action", description="Add a moderation action to be triggered when a banned URL is detected.")
-    @app_commands.describe(action="Action to perform", duration="Only required for timeout (e.g. 10m, 1h, 3d)")
+    @bannedurls_group.command(
+        name="add_action",
+        description=app_commands.locale_str(
+            "Add a moderation action to be triggered when a banned URL is detected.",
+            key="cogs.banned_urls.meta.add_action.description",
+        ),
+    )
+    @app_commands.describe(
+        action=app_commands.locale_str(
+            "Action to perform",
+            key="cogs.banned_urls.meta.add_action.params.action",
+        ),
+        duration=app_commands.locale_str(
+            "Only required for timeout (e.g. 10m, 1h, 3d)",
+            key="cogs.banned_urls.meta.add_action.params.duration",
+        ),
+    )
     @app_commands.choices(action=action_choices())
     async def add_banned_action(self, interaction: Interaction, action: str, duration: str = None, role: discord.Role = None, reason: str = None):
         await interaction.response.defer(ephemeral=True)
@@ -273,14 +288,31 @@ class BannedURLsCog(commands.Cog):
         msg = await manager.add_action(interaction.guild.id, action_str, translator=self.bot.translate)
         await interaction.followup.send(msg, ephemeral=True)
 
-    @bannedurls_group.command(name="remove_action", description="Remove a specific action from the list of punishments for banned URLs.")
-    @app_commands.describe(action="Exact action string to remove (e.g. timeout, delete)")
+    @bannedurls_group.command(
+        name="remove_action",
+        description=app_commands.locale_str(
+            "Remove a specific action from the list of punishments for banned URLs.",
+            key="cogs.banned_urls.meta.remove_action.description",
+        ),
+    )
+    @app_commands.describe(
+        action=app_commands.locale_str(
+            "Exact action string to remove (e.g. timeout, delete)",
+            key="cogs.banned_urls.meta.remove_action.params.action",
+        )
+    )
     @app_commands.autocomplete(action=manager.autocomplete)
     async def remove_banned_action(self, interaction: Interaction, action: str):
         msg = await manager.remove_action(interaction.guild.id, action, translator=self.bot.translate)
         await interaction.response.send_message(msg, ephemeral=True)
 
-    @bannedurls_group.command(name="view_actions", description="Show all actions currently configured to trigger when banned URLs are used.")
+    @bannedurls_group.command(
+        name="view_actions",
+        description=app_commands.locale_str(
+            "Show all actions currently configured to trigger when banned URLs are used.",
+            key="cogs.banned_urls.meta.view_actions.description",
+        ),
+    )
     async def view_banned_actions(self, interaction: Interaction):
         guild_id = interaction.guild.id
         actions = await manager.view_actions(interaction.guild.id)

--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -251,8 +251,19 @@ class Settings(commands.Cog):
             chunks.append(buf)
         return chunks
 
-    @app_commands.command(name="help", description="Get help on a specific command group.")
-    @app_commands.describe(command="Optional: command group to get help with")
+    @app_commands.command(
+        name="help",
+        description=app_commands.locale_str(
+            "Get help on a specific command group.",
+            key="cogs.settings.meta.help.description",
+        ),
+    )
+    @app_commands.describe(
+        command=app_commands.locale_str(
+            "Optional: command group to get help with",
+            key="cogs.settings.meta.help.params.command",
+        )
+    )
     @app_commands.default_permissions(moderate_members=True)
     async def help(self, interaction: Interaction, command: Optional[str] = None):
         await interaction.response.defer(ephemeral=True)

--- a/locales/en-US/cogs.banned_urls.json
+++ b/locales/en-US/cogs.banned_urls.json
@@ -14,6 +14,22 @@
         },
         "clear": {
           "description": "Clear all banned URLs."
+        },
+        "add_action": {
+          "description": "Add a moderation action to be triggered when a banned URL is detected.",
+          "params": {
+            "action": "Action to perform",
+            "duration": "Only required for timeout (e.g. 10m, 1h, 3d)"
+          }
+        },
+        "remove_action": {
+          "description": "Remove a specific action from the list of punishments for banned URLs.",
+          "params": {
+            "action": "Exact action string to remove (e.g. timeout, delete)"
+          }
+        },
+        "view_actions": {
+          "description": "Show all actions currently configured to trigger when banned URLs are used."
         }
       },
       "limit_reached": "You've reached the limit of {limit} banned URLs for this server.\nUse `/bannedurls remove` or `/bannedurls clear` to make space.",

--- a/locales/en-US/cogs.settings.json
+++ b/locales/en-US/cogs.settings.json
@@ -4,7 +4,10 @@
       "meta": {
         "group_description": "Manage server settings.",
         "help": {
-          "description": "Get help on settings."
+          "description": "Get help on a specific command group.",
+          "params": {
+            "command": "Optional: command group to get help with"
+          }
         },
         "reset": {
           "description": "Wipe all settings and start with defaults. This can't be undone"

--- a/locales/en/cogs.banned_urls.json
+++ b/locales/en/cogs.banned_urls.json
@@ -14,6 +14,22 @@
         },
         "clear": {
           "description": "Clear all banned URLs."
+        },
+        "add_action": {
+          "description": "Add a moderation action to be triggered when a banned URL is detected.",
+          "params": {
+            "action": "Action to perform",
+            "duration": "Only required for timeout (e.g. 10m, 1h, 3d)"
+          }
+        },
+        "remove_action": {
+          "description": "Remove a specific action from the list of punishments for banned URLs.",
+          "params": {
+            "action": "Exact action string to remove (e.g. timeout, delete)"
+          }
+        },
+        "view_actions": {
+          "description": "Show all actions currently configured to trigger when banned URLs are used."
         }
       },
       "limit_reached": "You've reached the limit of {limit} banned URLs for this server.\nUse `/bannedurls remove` or `/bannedurls clear` to make space.",

--- a/locales/en/cogs.settings.json
+++ b/locales/en/cogs.settings.json
@@ -4,7 +4,10 @@
       "meta": {
         "group_description": "Manage server settings.",
         "help": {
-          "description": "Get help on settings."
+          "description": "Get help on a specific command group.",
+          "params": {
+            "command": "Optional: command group to get help with"
+          }
         },
         "reset": {
           "description": "Wipe all settings and start with defaults. This can't be undone"


### PR DESCRIPTION
## Summary
- move banned URL action management command descriptions and parameter prompts into locale files
- localize the settings help slash command metadata and update progress log to reflect the new coverage

## Testing
- not run (not requested)

------