### PR TITLE
Fix command translation key lookup

### DIFF
--- a/modules/i18n/discord_translator.py
+++ b/modules/i18n/discord_translator.py
@@ -26,12 +26,13 @@ class DiscordAppCommandTranslator(app_commands.Translator):
         locale: Locale,
         context: app_commands.TranslationContext,
     ) -> str | None:
-        key: str | None = getattr(string, "key", None)
+        extras = getattr(string, "extras", None) or {}
+        key = extras.get("key")
         if not key:
             return None
 
-        placeholders: dict[str, Any] | None = getattr(string, "placeholders", None)
-        fallback = getattr(string, "default", getattr(string, "value", None))
+        placeholders = extras.get("placeholders")
+        fallback = extras.get("default", getattr(string, "message", None))
         return self._service.translate(
             key,
             locale=locale.value,

--- a/tests/test_moderator_bot_locale.py
+++ b/tests/test_moderator_bot_locale.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from discord import Locale, app_commands
 
 os.environ.setdefault(
     "FERNET_SECRET_KEY", "DeJ3sXDDTTbikeRSJzRgg8r_Ch61_NbE8D3LWnLOJO4="
@@ -18,6 +19,7 @@ from modules.config.settings_schema import SETTINGS_SCHEMA
 from modules.i18n.locale_utils import list_supported_locales
 from modules.core.moderator_bot import ModeratorBot
 from modules.utils import mysql
+from modules.i18n.discord_translator import DiscordAppCommandTranslator
 
 
 class DummyGuild(SimpleNamespace):
@@ -206,6 +208,22 @@ def test_push_and_reset_locale(bot: ModeratorBot) -> None:
 
     assert bot.current_locale() is None
 
+
+
+def test_discord_translator_uses_locale_extras(bot: ModeratorBot) -> None:
+    translator = DiscordAppCommandTranslator(bot.translation_service)
+    locale_string = app_commands.locale_str(
+        "Open the dashboard for this server.",
+        key="cogs.dashboard.meta.dashboard.description",
+    )
+    context = app_commands.TranslationContext(
+        location=app_commands.TranslationContextLocation.command_description,
+        data=None,
+    )
+
+    result = asyncio.run(translator.translate(locale_string, Locale.french, context))
+
+    assert result == "Ouvrez le tableau de bord pour ce serveur."
 
 
 def test_preload_guild_locale_cache(bot: ModeratorBot, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- ensure the Discord command translator reads locale metadata from locale_str.extras instead of missing attributes
- add a regression test verifying that slash command descriptions resolve to the translated text

## Testing
- pytest tests/test_moderator_bot_locale.py::test_discord_translator_uses_locale_extras -q

------
https://chatgpt.com/codex/tasks/task_e_68dbccd14144832d8785a4bfefa0a015