### PR TITLE
Streamline locale string handling across slash commands

### DIFF
--- a/cogs/accelerated.py
+++ b/cogs/accelerated.py
@@ -6,6 +6,7 @@ from modules.utils import mysql
 from datetime import timezone
 from discord.ui import View, Button
 from modules.core.moderator_bot import ModeratorBot
+from modules.i18n.strings import locale_string
 
 class AcceleratedCog(commands.Cog):
     """Commands for Moderator Bot Accelerated (Premium)."""
@@ -15,18 +16,12 @@ class AcceleratedCog(commands.Cog):
 
     accelerated_group = app_commands.Group(
         name="accelerated",
-        description=app_commands.locale_str(
-            "Manage your Accelerated (Premium) subscription.",
-            key="cogs.accelerated.meta.group_description",
-        ),
+        description=locale_string("cogs.accelerated.meta.group_description"),
     )
 
     @accelerated_group.command(
         name="status",
-        description=app_commands.locale_str(
-            "Check if you currently have an Accelerated subscription.",
-            key="cogs.accelerated.meta.status.description",
-        ),
+        description=locale_string("cogs.accelerated.meta.status.description"),
     )
     async def status(self, interaction: Interaction):
         """Check if you currently have an Accelerated subscription."""
@@ -115,10 +110,7 @@ class AcceleratedCog(commands.Cog):
 
     @accelerated_group.command(
         name="subscribe",
-        description=app_commands.locale_str(
-            "Generate your unique PayPal subscription link.",
-            key="cogs.accelerated.meta.subscribe.description",
-        ),
+        description=locale_string("cogs.accelerated.meta.subscribe.description"),
     )
     async def subscribe(self, interaction: Interaction):
         """Generate your unique PayPal subscription link."""
@@ -155,10 +147,7 @@ class AcceleratedCog(commands.Cog):
 
     @accelerated_group.command(
         name="perks",
-        description=app_commands.locale_str(
-            "Show the benefits of Accelerated subscription.",
-            key="cogs.accelerated.meta.perks.description",
-        ),
+        description=locale_string("cogs.accelerated.meta.perks.description"),
     )
     async def perks(self, interaction: Interaction):
         """Show the benefits of Accelerated subscription."""
@@ -174,10 +163,7 @@ class AcceleratedCog(commands.Cog):
 
     @accelerated_group.command(
         name="cancel",
-        description=app_commands.locale_str(
-            "Explain how to cancel your subscription.",
-            key="cogs.accelerated.meta.cancel.description",
-        ),
+        description=locale_string("cogs.accelerated.meta.cancel.description"),
     )
     async def cancel(self, interaction: Interaction):
         """Explain how to cancel your subscription."""

--- a/cogs/api_pool.py
+++ b/cogs/api_pool.py
@@ -8,6 +8,7 @@ import os
 from dotenv import load_dotenv
 import hashlib
 from modules.core.moderator_bot import ModeratorBot
+from modules.i18n.strings import locale_string
 
 load_dotenv()
 
@@ -26,18 +27,12 @@ class ApiPoolCog(commands.Cog):
 
     api_pool_group = app_commands.Group(
         name="api_pool",
-        description=app_commands.locale_str(
-            "Management of your personal API keys in the pool.",
-            key="cogs.api_pool.meta.group_description",
-        ),
+        description=locale_string("cogs.api_pool.meta.group_description"),
     )
 
     @api_pool_group.command(
         name="explanation",
-        description=app_commands.locale_str(
-            "Explain the API pool.",
-            key="cogs.api_pool.meta.explain.description",
-        ),
+        description=locale_string("cogs.api_pool.meta.explain.description"),
     )
     async def explain(self, interaction: Interaction):
         guild_id = interaction.guild.id
@@ -49,16 +44,10 @@ class ApiPoolCog(commands.Cog):
 
     @api_pool_group.command(
         name="add",
-        description=app_commands.locale_str(
-            "Add an API key to the pool.",
-            key="cogs.api_pool.meta.add.description",
-        ),
+        description=locale_string("cogs.api_pool.meta.add.description"),
     )
     @app_commands.describe(
-        api_key=app_commands.locale_str(
-            "The OpenAI API key to add to the shared pool.",
-            key="cogs.api_pool.meta.add.params.api_key",
-        )
+        api_key=locale_string("cogs.api_pool.meta.add.params.api_key")
     )
     async def add_api(self, interaction: Interaction, api_key: str):
         await interaction.response.defer(ephemeral=True)
@@ -117,16 +106,10 @@ class ApiPoolCog(commands.Cog):
 
     @api_pool_group.command(
         name="remove",
-        description=app_commands.locale_str(
-            "Remove an API key from the pool.",
-            key="cogs.api_pool.meta.remove.description",
-        ),
+        description=locale_string("cogs.api_pool.meta.remove.description"),
     )
     @app_commands.describe(
-        api_key=app_commands.locale_str(
-            "The OpenAI API key to remove from the shared pool.",
-            key="cogs.api_pool.meta.remove.params.api_key",
-        )
+        api_key=locale_string("cogs.api_pool.meta.remove.params.api_key")
     )
     async def remove_api(self, interaction: Interaction, api_key: str):
         user_id = interaction.user.id
@@ -148,10 +131,7 @@ class ApiPoolCog(commands.Cog):
 
     @api_pool_group.command(
         name="clear",
-        description=app_commands.locale_str(
-            "Clear all your API keys from the pool.",
-            key="cogs.api_pool.meta.clear.description",
-        ),
+        description=locale_string("cogs.api_pool.meta.clear.description"),
     )
     async def clear_api(self, interaction: Interaction):
         user_id = interaction.user.id
@@ -173,10 +153,7 @@ class ApiPoolCog(commands.Cog):
 
     @api_pool_group.command(
         name="list",
-        description=app_commands.locale_str(
-            "List all API keys in your pool (encrypted).",
-            key="cogs.api_pool.meta.list.description",
-        ),
+        description=locale_string("cogs.api_pool.meta.list.description"),
     )
     async def list_apis(self, interaction: Interaction):
         user_id = interaction.user.id

--- a/cogs/autonomous_moderation/auto_commands.py
+++ b/cogs/autonomous_moderation/auto_commands.py
@@ -9,6 +9,7 @@ from modules.utils.action_manager import ActionListManager
 from modules.utils.actions import VALID_ACTION_VALUES, action_choices
 from modules.utils.strike import validate_action
 from modules.core.moderator_bot import ModeratorBot
+from modules.i18n.strings import locale_string
 
 AIMOD_ACTION_SETTING = "aimod-detection-action"
 ACTION_MANAGER = ActionListManager(AIMOD_ACTION_SETTING)
@@ -63,20 +64,14 @@ class AutonomousCommandsCog(commands.Cog):
 
     ai_mod_group = app_commands.Group(
         name="ai_mod",
-        description=app_commands.locale_str(
-            "Manage AI moderation features.",
-            key="cogs.autonomous_moderation.meta.group_description",
-        ),
+        description=locale_string("cogs.autonomous_moderation.meta.group_description"),
         default_permissions=discord.Permissions(manage_messages=True),
         guild_only=True,
     )
 
     @ai_mod_group.command(
         name="rules_set",
-        description=app_commands.locale_str(
-            "Set server rules",
-            key="cogs.autonomous_moderation.meta.rules_set.description",
-        ),
+        description=locale_string("cogs.autonomous_moderation.meta.rules_set.description"),
     )
     @app_commands.default_permissions(manage_guild=True)
     async def set_rules(self, interaction: Interaction, *, rules: str):
@@ -90,10 +85,7 @@ class AutonomousCommandsCog(commands.Cog):
 
     @ai_mod_group.command(
         name="rules_show",
-        description=app_commands.locale_str(
-            "Show the currently configured moderation rules.",
-            key="cogs.autonomous_moderation.meta.rules_show.description",
-        ),
+        description=locale_string("cogs.autonomous_moderation.meta.rules_show.description"),
     )
     async def show_rules(self, interaction: Interaction):
         if not await can_run(interaction):
@@ -116,10 +108,7 @@ class AutonomousCommandsCog(commands.Cog):
 
     @ai_mod_group.command(
         name="add_action",
-        description=app_commands.locale_str(
-            "Add enforcement actions",
-            key="cogs.autonomous_moderation.meta.add_action.description",
-        ),
+        description=locale_string("cogs.autonomous_moderation.meta.add_action.description"),
     )
     @app_commands.default_permissions(manage_guild=True)
     @app_commands.choices(action=action_choices(include=[("Auto", "auto")]))
@@ -152,16 +141,10 @@ class AutonomousCommandsCog(commands.Cog):
 
     @ai_mod_group.command(
         name="remove_action",
-        description=app_commands.locale_str(
-            "Remove a specific action from the list of punishments.",
-            key="cogs.autonomous_moderation.meta.remove_action.description",
-        ),
+        description=locale_string("cogs.autonomous_moderation.meta.remove_action.description"),
     )
     @app_commands.describe(
-        action=app_commands.locale_str(
-            "Exact action string to remove (e.g. timeout, delete)",
-            key="cogs.autonomous_moderation.meta.remove_action.action",
-        )
+        action=locale_string("cogs.autonomous_moderation.meta.remove_action.action")
     )
     @app_commands.autocomplete(action=ACTION_MANAGER.autocomplete)
     async def remove_action(self, interaction: Interaction, action: str):
@@ -172,65 +155,38 @@ class AutonomousCommandsCog(commands.Cog):
 
     @ai_mod_group.command(
         name="toggle",
-        description=app_commands.locale_str(
-            "Enable/disable moderation, view status, or set mode.",
-            key="cogs.autonomous_moderation.meta.toggle.description",
-        ),
+        description=locale_string("cogs.autonomous_moderation.meta.toggle.description"),
     )
     @app_commands.describe(
-        enable=app_commands.locale_str(
-            "Turn autonomous moderation on or off.",
-            key="cogs.autonomous_moderation.meta.toggle.enable",
-        ),
-        mode=app_commands.locale_str(
-            "Optional: set report / interval / adaptive mode.",
-            key="cogs.autonomous_moderation.meta.toggle.mode",
-        ),
+        enable=locale_string("cogs.autonomous_moderation.meta.toggle.enable"),
+        mode=locale_string("cogs.autonomous_moderation.meta.toggle.mode"),
     )
     @app_commands.choices(
         enable=[
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "Enable",
-                    key="cogs.autonomous_moderation.meta.toggle.enable_choice",
-                ),
+                name=locale_string("cogs.autonomous_moderation.meta.toggle.enable_choice"),
                 value="enable",
             ),
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "Disable",
-                    key="cogs.autonomous_moderation.meta.toggle.disable_choice",
-                ),
+                name=locale_string("cogs.autonomous_moderation.meta.toggle.disable_choice"),
                 value="disable",
             ),
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "Status",
-                    key="cogs.autonomous_moderation.meta.toggle.status_choice",
-                ),
+                name=locale_string("cogs.autonomous_moderation.meta.toggle.status_choice"),
                 value="status",
             ),
         ],
         mode=[
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "Report",
-                    key="cogs.autonomous_moderation.meta.toggle.mode_choices.report",
-                ),
+                name=locale_string("cogs.autonomous_moderation.meta.toggle.mode_choices.report"),
                 value="report",
             ),
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "Interval",
-                    key="cogs.autonomous_moderation.meta.toggle.mode_choices.interval",
-                ),
+                name=locale_string("cogs.autonomous_moderation.meta.toggle.mode_choices.interval"),
                 value="interval",
             ),
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "Adaptive",
-                    key="cogs.autonomous_moderation.meta.toggle.mode_choices.adaptive",
-                ),
+                name=locale_string("cogs.autonomous_moderation.meta.toggle.mode_choices.adaptive"),
                 value="adaptive",
             ),
         ],
@@ -277,10 +233,7 @@ class AutonomousCommandsCog(commands.Cog):
 
     @ai_mod_group.command(
         name="view_actions",
-        description=app_commands.locale_str(
-            "Show all actions currently configured to trigger when the AI detects a violation.",
-            key="cogs.autonomous_moderation.meta.view_actions.description",
-        ),
+        description=locale_string("cogs.autonomous_moderation.meta.view_actions.description"),
     )
     async def view_actions(self, interaction: Interaction):
         if not await can_run(interaction):
@@ -301,40 +254,25 @@ class AutonomousCommandsCog(commands.Cog):
 
     @ai_mod_group.command(
         name="add_adaptive_event",
-        description=app_commands.locale_str(
-            "Link a trigger event to one or more moderation mode actions.",
-            key="cogs.autonomous_moderation.meta.add_adaptive_event.description",
-        ),
+        description=locale_string("cogs.autonomous_moderation.meta.add_adaptive_event.description"),
     )
     @app_commands.describe(
-        role=app_commands.locale_str(
-            "Which roles to monitor (if applicable)",
-            key="cogs.autonomous_moderation.meta.add_adaptive_event.role",
-        ),
-        channel=app_commands.locale_str(
-            "Which channel to monitor (for spike events)",
-            key="cogs.autonomous_moderation.meta.add_adaptive_event.channel",
-        ),
-        time_range=app_commands.locale_str(
-            "Time range in HH:MM-HH:MM for time-based triggers",
-            key="cogs.autonomous_moderation.meta.add_adaptive_event.time_range",
-        ),
-        threshold=app_commands.locale_str(
-            "Threshold for role online percent (0 to 1, optional)",
-            key="cogs.autonomous_moderation.meta.add_adaptive_event.threshold",
-        ),
+        role=locale_string("cogs.autonomous_moderation.meta.add_adaptive_event.role"),
+        channel=locale_string("cogs.autonomous_moderation.meta.add_adaptive_event.channel"),
+        time_range=locale_string("cogs.autonomous_moderation.meta.add_adaptive_event.time_range"),
+        threshold=locale_string("cogs.autonomous_moderation.meta.add_adaptive_event.threshold"),
     )
     @app_commands.choices(
         event=[
             app_commands.Choice(
-                name=app_commands.locale_str(label, key=key),
+                name=locale_string(key, default=label),
                 value=value,
             )
             for label, value, key in ADAPTIVE_EVENTS
         ],
         action=[
             app_commands.Choice(
-                name=app_commands.locale_str(label, key=key),
+                name=locale_string(key, default=label),
                 value=value,
             )
             for label, value, key in ACTIONS
@@ -398,26 +336,17 @@ class AutonomousCommandsCog(commands.Cog):
 
     @ai_mod_group.command(
         name="remove_adaptive_event",
-        description=app_commands.locale_str(
-            "Remove a specific action from a configured event.",
-            key="cogs.autonomous_moderation.meta.remove_adaptive_event.description",
-        ),
+        description=locale_string("cogs.autonomous_moderation.meta.remove_adaptive_event.description"),
     )
     @app_commands.describe(
-        event_key=app_commands.locale_str(
-            "Adaptive event key (autocompletes)",
-            key="cogs.autonomous_moderation.meta.remove_adaptive_event.event_key",
-        ),
-        action=app_commands.locale_str(
-            "Action to remove from this event",
-            key="cogs.autonomous_moderation.meta.remove_adaptive_event.action",
-        ),
+        event_key=locale_string("cogs.autonomous_moderation.meta.remove_adaptive_event.event_key"),
+        action=locale_string("cogs.autonomous_moderation.meta.remove_adaptive_event.action"),
     )
     @app_commands.autocomplete(event_key=EVENT_MANAGER.autocomplete_event)
     @app_commands.choices(
         action=[
             app_commands.Choice(
-                name=app_commands.locale_str(label, key=key),
+                name=locale_string(key, default=label),
                 value=value,
             )
             for label, value, key in ACTIONS
@@ -433,10 +362,7 @@ class AutonomousCommandsCog(commands.Cog):
 
     @ai_mod_group.command(
         name="clear_adaptive_events",
-        description=app_commands.locale_str(
-            "Clear all adaptive event triggers.",
-            key="cogs.autonomous_moderation.meta.clear_adaptive_events.description",
-        ),
+        description=locale_string("cogs.autonomous_moderation.meta.clear_adaptive_events.description"),
     )
     async def clear_adaptive_events(self, interaction: Interaction):
         if not await can_run(interaction):
@@ -451,10 +377,7 @@ class AutonomousCommandsCog(commands.Cog):
 
     @ai_mod_group.command(
         name="view_adaptive_events",
-        description=app_commands.locale_str(
-            "Show current adaptive moderation triggers.",
-            key="cogs.autonomous_moderation.meta.view_adaptive_events.description",
-        ),
+        description=locale_string("cogs.autonomous_moderation.meta.view_adaptive_events.description"),
     )
     async def view_adaptive_events(self, interaction: Interaction):
         if not await can_run(interaction):

--- a/cogs/banned_urls.py
+++ b/cogs/banned_urls.py
@@ -11,6 +11,7 @@ from modules.utils.actions import action_choices, VALID_ACTION_VALUES
 from modules.utils.url_utils import extract_urls, norm_domain, norm_url
 from urllib.parse import urlparse
 from modules.core.moderator_bot import ModeratorBot
+from modules.i18n.strings import locale_string
 
 MAX_URLS = 500
 BANNEDURLS_ACTION_SETTING = "url-detection-action"
@@ -29,20 +30,14 @@ class BannedURLsCog(commands.Cog):
     
     bannedurls_group = app_commands.Group(
         name="bannedurls",
-        description=app_commands.locale_str(
-            "Banned URLs management commands.",
-            key="cogs.banned_urls.meta.group_description",
-        ),
+        description=locale_string("cogs.banned_urls.meta.group_description"),
         default_permissions=discord.Permissions(manage_messages=True),
         guild_only=True
     )
 
     @bannedurls_group.command(
         name="add",
-        description=app_commands.locale_str(
-            "Add a URL or domain to the banned list.",
-            key="cogs.banned_urls.meta.add.description",
-        ),
+        description=locale_string("cogs.banned_urls.meta.add.description"),
     )
     async def add_banned_urls(self, interaction: Interaction, url: str):
         guild_id = interaction.guild.id
@@ -88,10 +83,7 @@ class BannedURLsCog(commands.Cog):
 
     @bannedurls_group.command(
         name="remove",
-        description=app_commands.locale_str(
-            "Remove a URL or domain from the banned list.",
-            key="cogs.banned_urls.meta.remove.description",
-        ),
+        description=locale_string("cogs.banned_urls.meta.remove.description"),
     )
     async def remove_banned_urls(self, interaction: Interaction, url: str):
         guild_id = interaction.guild.id
@@ -127,10 +119,7 @@ class BannedURLsCog(commands.Cog):
 
     @bannedurls_group.command(
         name="list",
-        description=app_commands.locale_str(
-            "List all banned URLs.",
-            key="cogs.banned_urls.meta.list.description",
-        ),
+        description=locale_string("cogs.banned_urls.meta.list.description"),
     )
     async def list_banned_urls(self, interaction: Interaction):
         guild_id = interaction.guild.id
@@ -159,10 +148,7 @@ class BannedURLsCog(commands.Cog):
 
     @bannedurls_group.command(
         name="clear",
-        description=app_commands.locale_str(
-            "Clear all banned URLs.",
-            key="cogs.banned_urls.meta.clear.description",
-        ),
+        description=locale_string("cogs.banned_urls.meta.clear.description"),
     )
     async def clear_banned_urls(self, interaction: Interaction):
         guild_id = interaction.guild.id
@@ -264,20 +250,11 @@ class BannedURLsCog(commands.Cog):
 
     @bannedurls_group.command(
         name="add_action",
-        description=app_commands.locale_str(
-            "Add a moderation action to be triggered when a banned URL is detected.",
-            key="cogs.banned_urls.meta.actions.add.description",
-        ),
+        description=locale_string("cogs.banned_urls.meta.actions.add.description"),
     )
     @app_commands.describe(
-        action=app_commands.locale_str(
-            "Action to perform",
-            key="cogs.banned_urls.meta.actions.add.options.action",
-        ),
-        duration=app_commands.locale_str(
-            "Only required for timeout (e.g. 10m, 1h, 3d)",
-            key="cogs.banned_urls.meta.actions.add.options.duration",
-        ),
+        action=locale_string("cogs.banned_urls.meta.actions.add.options.action"),
+        duration=locale_string("cogs.banned_urls.meta.actions.add.options.duration"),
     )
     @app_commands.choices(action=action_choices())
     async def add_banned_action(self, interaction: Interaction, action: str, duration: str = None, role: discord.Role = None, reason: str = None):
@@ -290,16 +267,10 @@ class BannedURLsCog(commands.Cog):
 
     @bannedurls_group.command(
         name="remove_action",
-        description=app_commands.locale_str(
-            "Remove a specific action from the list of punishments for banned URLs.",
-            key="cogs.banned_urls.meta.actions.remove.description",
-        ),
+        description=locale_string("cogs.banned_urls.meta.actions.remove.description"),
     )
     @app_commands.describe(
-        action=app_commands.locale_str(
-            "Exact action string to remove (e.g. timeout, delete)",
-            key="cogs.banned_urls.meta.actions.remove.options.action",
-        )
+        action=locale_string("cogs.banned_urls.meta.actions.remove.options.action")
     )
     @app_commands.autocomplete(action=manager.autocomplete)
     async def remove_banned_action(self, interaction: Interaction, action: str):
@@ -308,10 +279,7 @@ class BannedURLsCog(commands.Cog):
 
     @bannedurls_group.command(
         name="view_actions",
-        description=app_commands.locale_str(
-            "Show all actions currently configured to trigger when banned URLs are used.",
-            key="cogs.banned_urls.meta.actions.view.description",
-        ),
+        description=locale_string("cogs.banned_urls.meta.actions.view.description"),
     )
     async def view_banned_actions(self, interaction: Interaction):
         guild_id = interaction.guild.id

--- a/cogs/banned_words.py
+++ b/cogs/banned_words.py
@@ -10,6 +10,7 @@ from better_profanity import profanity
 from cleantext import clean
 from modules.utils import mod_logging, mysql
 from modules.utils.strike import validate_action
+from modules.i18n.strings import locale_namespace
 from modules.utils.actions import action_choices, VALID_ACTION_VALUES
 from modules.utils.text import normalize_text
 from modules.core.moderator_bot import ModeratorBot
@@ -20,6 +21,12 @@ manager = ActionListManager(BANNED_ACTION_SETTING)
 
 RE_REPEATS = re.compile(r"(.)\1{2,}")
 
+LOCALE = locale_namespace("cogs", "banned_words")
+META = LOCALE.child("meta")
+DEFAULT_CHOICES = META.child("defaults", "choices")
+ADD_ACTION_PARAMS = META.child("add_action", "params")
+REMOVE_ACTION_PARAMS = META.child("remove_action", "params")
+
 class BannedWordsCog(commands.Cog):
 
     """A cog for banned words handling and relevant commands."""
@@ -28,42 +35,27 @@ class BannedWordsCog(commands.Cog):
     
     bannedwords_group = app_commands.Group(
         name="bannedwords",
-        description=app_commands.locale_str(
-            "Banned words management commands.",
-            key="cogs.banned_words.meta.group_description",
-        ),
+        description=META.string("group_description"),
         default_permissions=discord.Permissions(manage_messages=True),
         guild_only=True
     )
 
     @bannedwords_group.command(
         name="defaults",
-        description=app_commands.locale_str(
-            "Enable or disable the built-in profanity list.",
-            key="cogs.banned_words.meta.defaults.description",
-        ),
+        description=META.string("defaults", "description"),
     )
     @app_commands.choices(
         action=[
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "enable",
-                    key="cogs.banned_words.meta.defaults.choices.enable",
-                ),
+                name=DEFAULT_CHOICES.string("enable"),
                 value="true",
             ),
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "disable",
-                    key="cogs.banned_words.meta.defaults.choices.disable",
-                ),
+                name=DEFAULT_CHOICES.string("disable"),
                 value="false",
             ),
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "status",
-                    key="cogs.banned_words.meta.defaults.choices.status",
-                ),
+                name=DEFAULT_CHOICES.string("status"),
                 value="status",
             ),
         ]
@@ -107,10 +99,7 @@ class BannedWordsCog(commands.Cog):
 
     @bannedwords_group.command(
         name="add",
-        description=app_commands.locale_str(
-            "Add a word to the banned words list.",
-            key="cogs.banned_words.meta.add.description",
-        ),
+        description=META.string("add", "description"),
     )
     async def add_banned_word(self, interaction: Interaction, word: str):
         """Add a word to the banned words list."""
@@ -161,10 +150,7 @@ class BannedWordsCog(commands.Cog):
     # Remove a banned word
     @bannedwords_group.command(
         name="remove",
-        description=app_commands.locale_str(
-            "Remove a word from the banned words list.",
-            key="cogs.banned_words.meta.remove.description",
-        ),
+        description=META.string("remove", "description"),
     )
     async def remove_banned_word(self, interaction: Interaction, word: str):
         """Remove a word from the banned words list."""
@@ -218,10 +204,7 @@ class BannedWordsCog(commands.Cog):
     # List banned words (in a text file)
     @bannedwords_group.command(
         name="list",
-        description=app_commands.locale_str(
-            "List all banned words.",
-            key="cogs.banned_words.meta.list.description",
-        ),
+        description=META.string("list", "description"),
     )
     async def list_banned_words(self, interaction: Interaction):
         """List all banned words."""
@@ -259,10 +242,7 @@ class BannedWordsCog(commands.Cog):
     # Clear all banned words
     @bannedwords_group.command(
         name="clear",
-        description=app_commands.locale_str(
-            "Clear all banned words.",
-            key="cogs.banned_words.meta.clear.description",
-        ),
+        description=META.string("clear", "description"),
     )
     async def clear_banned_words(self, interaction: Interaction):
         """Clear all banned words."""
@@ -375,20 +355,11 @@ class BannedWordsCog(commands.Cog):
 
     @bannedwords_group.command(
         name="add_action",
-        description=app_commands.locale_str(
-            "Add a moderation action to be triggered when a banned word is detected.",
-            key="cogs.banned_words.meta.add_action.description",
-        ),
+        description=META.string("add_action", "description"),
     )
     @app_commands.describe(
-        action=app_commands.locale_str(
-            "Action to perform",
-            key="cogs.banned_words.meta.add_action.params.action",
-        ),
-        duration=app_commands.locale_str(
-            "Only required for timeout (e.g. 10m, 1h, 3d)",
-            key="cogs.banned_words.meta.add_action.params.duration",
-        ),
+        action=ADD_ACTION_PARAMS.string("action"),
+        duration=ADD_ACTION_PARAMS.string("duration"),
     )
     @app_commands.choices(action=action_choices())
     async def add_banned_action(
@@ -418,16 +389,10 @@ class BannedWordsCog(commands.Cog):
 
     @bannedwords_group.command(
         name="remove_action",
-        description=app_commands.locale_str(
-            "Remove a specific action from the list of punishments for banned words.",
-            key="cogs.banned_words.meta.remove_action.description",
-        ),
+        description=META.string("remove_action", "description"),
     )
     @app_commands.describe(
-        action=app_commands.locale_str(
-            "Exact action string to remove (e.g. timeout, delete)",
-            key="cogs.banned_words.meta.remove_action.params.action",
-        )
+        action=REMOVE_ACTION_PARAMS.string("action")
     )
     @app_commands.autocomplete(action=manager.autocomplete)
     async def remove_banned_action(self, interaction: Interaction, action: str):
@@ -436,10 +401,7 @@ class BannedWordsCog(commands.Cog):
 
     @bannedwords_group.command(
         name="view_actions",
-        description=app_commands.locale_str(
-            "Show all actions currently configured to trigger when banned words are used.",
-            key="cogs.banned_words.meta.view_actions.description",
-        ),
+        description=META.string("view_actions", "description"),
     )
     async def view_banned_actions(self, interaction: Interaction):
         actions = await manager.view_actions(interaction.guild.id)

--- a/cogs/captcha/cog.py
+++ b/cogs/captcha/cog.py
@@ -19,6 +19,7 @@ from modules.captcha import (
 )
 from modules.captcha.client import CaptchaApiClient, CaptchaGuildConfig
 from modules.captcha.sessions import CaptchaSessionStore
+from modules.i18n.strings import locale_namespace
 from modules.utils import mysql
 from modules.utils.discord_utils import resolve_role_references
 from modules.utils.time import parse_duration
@@ -31,16 +32,16 @@ from modules.core.moderator_bot import ModeratorBot
 
 _logger = logging.getLogger(__name__)
 
+CAPTCHA_LOCALE = locale_namespace("cogs", "captcha")
+CAPTCHA_META = CAPTCHA_LOCALE.child("meta")
+
 
 class CaptchaCog(CaptchaEmbedMixin, CaptchaDeliveryMixin, commands.Cog):
     """Captcha verification flow for new guild members."""
 
     captcha_group = app_commands.Group(
         name="captcha",
-        description=app_commands.locale_str(
-            "Manage captcha verification.",
-            key="cogs.captcha.meta.group_description",
-        ),
+        description=CAPTCHA_META.string("group_description"),
         guild_only=True,
         default_permissions=discord.Permissions(manage_guild=True),
     )
@@ -76,10 +77,7 @@ class CaptchaCog(CaptchaEmbedMixin, CaptchaDeliveryMixin, commands.Cog):
 
     @captcha_group.command(
         name="sync",
-        description=app_commands.locale_str(
-            "Resend the captcha verification embed.",
-            key="cogs.captcha.meta.sync.description",
-        ),
+        description=CAPTCHA_META.string("sync", "description"),
     )
     async def sync_embed_command(self, interaction: Interaction) -> None:
         guild_id = interaction.guild.id
@@ -120,16 +118,10 @@ class CaptchaCog(CaptchaEmbedMixin, CaptchaDeliveryMixin, commands.Cog):
 
     @captcha_group.command(
         name="request",
-        description=app_commands.locale_str(
-            "Send a captcha verification request to a member.",
-            key="cogs.captcha.meta.request.description",
-        ),
+        description=CAPTCHA_META.string("request", "description"),
     )
     @app_commands.describe(
-        member=app_commands.locale_str(
-            "The member who should complete verification",
-            key="cogs.captcha.meta.request.member",
-        )
+        member=CAPTCHA_META.string("request", "member")
     )
     async def request_verification_command(
         self, interaction: Interaction, member: discord.Member

--- a/cogs/channel_config.py
+++ b/cogs/channel_config.py
@@ -3,6 +3,7 @@ from discord.ext import commands
 from discord import app_commands, Interaction
 from modules.utils import mysql
 from modules.core.moderator_bot import ModeratorBot
+from modules.i18n.strings import locale_string
 
 LOG_CHANNEL_TYPES: dict[str, tuple[str, str, str]] = {
     "strike": ("strike-channel", "Strike", "cogs.channel_config.meta.types.strike"),
@@ -21,7 +22,7 @@ LOG_CHANNEL_TYPES: dict[str, tuple[str, str, str]] = {
 def _channel_type_choices() -> list[app_commands.Choice[str]]:
     return [
         app_commands.Choice(
-            name=app_commands.locale_str(default_label, key=translation_key),
+            name=locale_string(translation_key, default=default_label),
             value=identifier,
         )
         for identifier, (_, default_label, translation_key) in LOG_CHANNEL_TYPES.items()
@@ -33,30 +34,18 @@ class ChannelConfigCog(commands.Cog):
 
     channels_group = app_commands.Group(
         name="channels",
-        description=app_commands.locale_str(
-            "Configure log channels.",
-            key="cogs.channel_config.meta.group_description",
-        ),
+        description=locale_string("cogs.channel_config.meta.group_description"),
         guild_only=True,
         default_permissions=discord.Permissions(manage_guild=True),
     )
 
     @channels_group.command(
         name="set",
-        description=app_commands.locale_str(
-            "Set a log channel.",
-            key="cogs.channel_config.meta.set.description",
-        ),
+        description=locale_string("cogs.channel_config.meta.set.description"),
     )
     @app_commands.describe(
-        channel=app_commands.locale_str(
-            "The channel to use for logging.",
-            key="cogs.channel_config.meta.set.params.channel",
-        ),
-        type=app_commands.locale_str(
-            "Which type of log this channel is for.",
-            key="cogs.channel_config.meta.set.params.type",
-        ),
+        channel=locale_string("cogs.channel_config.meta.set.params.channel"),
+        type=locale_string("cogs.channel_config.meta.set.params.type"),
     )
     @app_commands.choices(type=_channel_type_choices())
     async def set_channel(
@@ -111,16 +100,10 @@ class ChannelConfigCog(commands.Cog):
 
     @channels_group.command(
         name="unset",
-        description=app_commands.locale_str(
-            "Unset a log channel.",
-            key="cogs.channel_config.meta.unset.description",
-        ),
+        description=locale_string("cogs.channel_config.meta.unset.description"),
     )
     @app_commands.describe(
-        type=app_commands.locale_str(
-            "Which log type to disable.",
-            key="cogs.channel_config.meta.unset.params.type",
-        )
+        type=locale_string("cogs.channel_config.meta.unset.params.type")
     )
     @app_commands.choices(type=_channel_type_choices())
     async def unset_channel(self, interaction: Interaction, type: app_commands.Choice[str]):
@@ -139,10 +122,7 @@ class ChannelConfigCog(commands.Cog):
 
     @channels_group.command(
         name="show",
-        description=app_commands.locale_str(
-            "Show current log channel settings.",
-            key="cogs.channel_config.meta.show.description",
-        ),
+        description=locale_string("cogs.channel_config.meta.show.description"),
     )
     async def show_channels(self, interaction: Interaction):
         show_texts = self.bot.translate("cogs.channel_config.show")

--- a/cogs/dashboard.py
+++ b/cogs/dashboard.py
@@ -1,6 +1,11 @@
-﻿from discord.ext import commands
+from discord.ext import commands
 from discord import Color, Embed, Interaction, app_commands
+
 from modules.core.moderator_bot import ModeratorBot
+from modules.i18n.strings import locale_namespace
+
+DASHBOARD_LOCALE = locale_namespace("cogs", "dashboard")
+
 
 class DashboardCog(commands.Cog):
     def __init__(self, bot: ModeratorBot):
@@ -8,10 +13,7 @@ class DashboardCog(commands.Cog):
 
     @app_commands.command(
         name="dashboard",
-        description=app_commands.locale_str(
-            "Open the dashboard for this server.",
-            key="cogs.dashboard.meta.dashboard.description",
-        ),
+        description=DASHBOARD_LOCALE.child("meta", "dashboard").string("description"),
     )
     @app_commands.guild_only()
     @app_commands.default_permissions(administrator=True)
@@ -23,14 +25,13 @@ class DashboardCog(commands.Cog):
         await interaction.response.defer(ephemeral=True, thinking=True)
 
         embed = Embed(
-            title=self.bot.translate("cogs.dashboard.embed.title",
-                                     guild_id=guild_id),
+            title=self.bot.translate("cogs.dashboard.embed.title", guild_id=guild_id),
             description=self.bot.translate(
                 "cogs.dashboard.embed.description",
                 placeholders={"url": backend_url},
                 guild_id=guild_id,
             ),
-            color=Color.blurple()
+            color=Color.blurple(),
         )
         if self.bot.user:
             embed.set_thumbnail(url=self.bot.user.display_avatar.url)

--- a/cogs/debug.py
+++ b/cogs/debug.py
@@ -8,6 +8,7 @@ import os
 import platform
 import time
 from modules.core.moderator_bot import ModeratorBot
+from modules.i18n.strings import locale_string
 
 load_dotenv()
 GUILD_ID = int(os.getenv('GUILD_ID', 0))
@@ -24,17 +25,11 @@ class DebugCog(commands.Cog):
 
     @app_commands.command(
         name="stats",
-        description=app_commands.locale_str(
-            "Get memory and performance stats",
-            key="cogs.debug.meta.stats.description",
-        ),
+        description=locale_string("cogs.debug.meta.stats.description"),
     )
     @app_commands.guilds(discord.Object(id=GUILD_ID))
     @app_commands.describe(
-        show_all=app_commands.locale_str(
-            "Include allocations from all libraries (not just project)",
-            key="cogs.debug.meta.stats.show_all",
-        )
+        show_all=locale_string("cogs.debug.meta.stats.show_all")
     )
     @app_commands.checks.has_permissions(administrator=True)
     async def stats(self, interaction: discord.Interaction, show_all: bool = True):
@@ -182,10 +177,7 @@ class DebugCog(commands.Cog):
 
     @app_commands.command(
         name="locale",
-        description=app_commands.locale_str(
-            "Show the locale currently bound to this command context",
-            key="cogs.debug.meta.locale.description",
-        ),
+        description=locale_string("cogs.debug.meta.locale.description"),
     )
     async def current_locale(self, interaction: discord.Interaction):
         current = self.bot.current_locale()

--- a/cogs/monitoring.py
+++ b/cogs/monitoring.py
@@ -7,6 +7,7 @@ from modules.utils import mysql
 from discord.utils import format_dt, utcnow
 from discord import app_commands
 from modules.core.moderator_bot import ModeratorBot
+from modules.i18n.strings import locale_string
 
 class MonitoringCog(commands.Cog):
     def __init__(self, bot: ModeratorBot):
@@ -443,26 +444,17 @@ class MonitoringCog(commands.Cog):
 
     monitor_group = app_commands.Group(
         name="monitor",
-        description=app_commands.locale_str(
-            "Monitoring configuration",
-            key="cogs.monitoring.meta.group_description",
-        ),
+        description=locale_string("cogs.monitoring.meta.group_description"),
         guild_only=True,
         default_permissions=discord.Permissions(manage_messages=True),
     )
 
     @monitor_group.command(
         name="set",
-        description=app_commands.locale_str(
-            "Set channel to output logs.",
-            key="cogs.monitoring.meta.set.description",
-        ),
+        description=locale_string("cogs.monitoring.meta.set.description"),
     )
     @app_commands.describe(
-        channel=app_commands.locale_str(
-            "The channel to send logs to.",
-            key="cogs.monitoring.meta.set.channel",
-        )
+        channel=locale_string("cogs.monitoring.meta.set.channel")
     )
     async def monitor_set(self, interaction: Interaction, channel: discord.TextChannel):
         guild_id = interaction.guild.id
@@ -476,10 +468,7 @@ class MonitoringCog(commands.Cog):
 
     @monitor_group.command(
         name="remove",
-        description=app_commands.locale_str(
-            "Remove the monitor channel setting.",
-            key="cogs.monitoring.meta.remove.description",
-        ),
+        description=locale_string("cogs.monitoring.meta.remove.description"),
     )
     async def monitor_remove(self, interaction: Interaction):
         guild_id = interaction.guild.id
@@ -493,10 +482,7 @@ class MonitoringCog(commands.Cog):
 
     @monitor_group.command(
         name="show",
-        description=app_commands.locale_str(
-            "Show the current monitor channel.",
-            key="cogs.monitoring.meta.show.description",
-        ),
+        description=locale_string("cogs.monitoring.meta.show.description"),
     )
     async def monitor_show(self, interaction: Interaction):
         guild_id = interaction.guild.id
@@ -515,70 +501,40 @@ class MonitoringCog(commands.Cog):
 
     @monitor_group.command(
         name="toggle_event",
-        description=app_commands.locale_str(
-            "Enable or disable a specific monitoring event.",
-            key="cogs.monitoring.meta.toggle_event.description",
-        ),
+        description=locale_string("cogs.monitoring.meta.toggle_event.description"),
     )
     @app_commands.describe(
-        event=app_commands.locale_str(
-            "The event to toggle",
-            key="cogs.monitoring.meta.toggle_event.event",
-        ),
-        enabled=app_commands.locale_str(
-            "Enable or disable logging for this event",
-            key="cogs.monitoring.meta.toggle_event.enabled",
-        ),
+        event=locale_string("cogs.monitoring.meta.toggle_event.event"),
+        enabled=locale_string("cogs.monitoring.meta.toggle_event.enabled"),
     )
     @app_commands.choices(
         event=[
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "User Join",
-                    key="cogs.monitoring.meta.toggle_event.choices.join",
-                ),
+                name=locale_string("cogs.monitoring.meta.toggle_event.choices.join"),
                 value="join",
             ),
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "User Leave",
-                    key="cogs.monitoring.meta.toggle_event.choices.leave",
-                ),
+                name=locale_string("cogs.monitoring.meta.toggle_event.choices.leave"),
                 value="leave",
             ),
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "Ban",
-                    key="cogs.monitoring.meta.toggle_event.choices.ban",
-                ),
+                name=locale_string("cogs.monitoring.meta.toggle_event.choices.ban"),
                 value="ban",
             ),
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "Unban",
-                    key="cogs.monitoring.meta.toggle_event.choices.unban",
-                ),
+                name=locale_string("cogs.monitoring.meta.toggle_event.choices.unban"),
                 value="unban",
             ),
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "Timeout",
-                    key="cogs.monitoring.meta.toggle_event.choices.timeout",
-                ),
+                name=locale_string("cogs.monitoring.meta.toggle_event.choices.timeout"),
                 value="timeout",
             ),
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "Message Deleted",
-                    key="cogs.monitoring.meta.toggle_event.choices.message_delete",
-                ),
+                name=locale_string("cogs.monitoring.meta.toggle_event.choices.message_delete"),
                 value="message_delete",
             ),
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "Message Edited",
-                    key="cogs.monitoring.meta.toggle_event.choices.message_edit",
-                ),
+                name=locale_string("cogs.monitoring.meta.toggle_event.choices.message_edit"),
                 value="message_edit",
             ),
         ]
@@ -598,10 +554,7 @@ class MonitoringCog(commands.Cog):
 
     @monitor_group.command(
         name="list_events",
-        description=app_commands.locale_str(
-            "List current monitor event settings.",
-            key="cogs.monitoring.meta.list_events.description",
-        ),
+        description=locale_string("cogs.monitoring.meta.list_events.description"),
     )
     async def list_events(self, interaction: Interaction):
         guild_id = interaction.guild.id

--- a/cogs/nsfw.py
+++ b/cogs/nsfw.py
@@ -2,6 +2,7 @@ import discord
 from discord.ext import commands
 from discord import app_commands, Interaction
 
+from modules.i18n.strings import locale_namespace
 from modules.utils import mysql
 from modules.utils.action_manager import ActionListManager
 from modules.utils.discord_utils import require_accelerated
@@ -15,36 +16,28 @@ manager = ActionListManager(NSFW_ACTION_SETTING)
 NSFW_CATEGORY_SETTING = "nsfw-detection-categories"
 category_manager = ListManager(NSFW_CATEGORY_SETTING)
 
+NSFW_LOCALE = locale_namespace("cogs", "nsfw")
+NSFW_META = NSFW_LOCALE.child("meta")
+NSFW_CATEGORY_LABELS = NSFW_META.child("categories")
+
 class NSFWCog(commands.Cog):
     def __init__(self, bot: ModeratorBot):
         self.bot = bot
 
     nsfw_group = app_commands.Group(
         name="nsfw",
-        description=app_commands.locale_str(
-            "Manage NSFW content detection.",
-            key="cogs.nsfw.meta.group_description",
-        ),
+        description=NSFW_META.string("group_description"),
         guild_only=True,
         default_permissions=discord.Permissions(manage_messages=True),
     )
 
     @nsfw_group.command(
         name="add_action",
-        description=app_commands.locale_str(
-            "Add an action to the NSFW punishment list.",
-            key="cogs.nsfw.meta.add_action.description",
-        ),
+        description=NSFW_META.string("add_action", "description"),
     )
     @app_commands.describe(
-        action=app_commands.locale_str(
-            "Action to perform",
-            key="cogs.nsfw.meta.add_action.params.action",
-        ),
-        duration=app_commands.locale_str(
-            "Only required for timeout (e.g. 10m, 1h, 3d)",
-            key="cogs.nsfw.meta.add_action.params.duration",
-        ),
+        action=NSFW_META.child("add_action", "params").string("action"),
+        duration=NSFW_META.child("add_action", "params").string("duration"),
     )
     @app_commands.choices(action=action_choices())
     async def add_nsfw_action(
@@ -75,16 +68,10 @@ class NSFWCog(commands.Cog):
 
     @nsfw_group.command(
         name="remove_action",
-        description=app_commands.locale_str(
-            "Remove an action from the NSFW punishment list.",
-            key="cogs.nsfw.meta.remove_action.description",
-        ),
+        description=NSFW_META.string("remove_action", "description"),
     )
     @app_commands.describe(
-        action=app_commands.locale_str(
-            "Exact action string to remove (e.g. timeout, delete)",
-            key="cogs.nsfw.meta.remove_action.params.action",
-        )
+        action=NSFW_META.child("remove_action", "params").string("action")
     )
     @app_commands.autocomplete(action=manager.autocomplete)
     async def remove_nsfw_action(self, interaction: Interaction, action: str):
@@ -95,10 +82,7 @@ class NSFWCog(commands.Cog):
 
     @nsfw_group.command(
         name="view_actions",
-        description=app_commands.locale_str(
-            "View the current list of NSFW punishment actions.",
-            key="cogs.nsfw.meta.view_actions.description",
-        ),
+        description=NSFW_META.string("view_actions", "description"),
     )
     async def view_nsfw_actions(self, interaction: Interaction):
         gid = interaction.guild.id
@@ -118,53 +102,32 @@ class NSFWCog(commands.Cog):
 
     @nsfw_group.command(
         name="add_category",
-        description=app_commands.locale_str(
-            "Add a category to NSFW detection.",
-            key="cogs.nsfw.meta.add_category.description",
-        ),
+        description=NSFW_META.string("add_category", "description"),
     )
     @app_commands.choices(
         category=[
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "Violence Graphic",
-                    key="cogs.nsfw.meta.categories.violence_graphic",
-                ),
+                name=NSFW_CATEGORY_LABELS.string("violence_graphic"),
                 value="violence_graphic",
             ),
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "Violence",
-                    key="cogs.nsfw.meta.categories.violence",
-                ),
+                name=NSFW_CATEGORY_LABELS.string("violence"),
                 value="violence",
             ),
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "Sexual",
-                    key="cogs.nsfw.meta.categories.sexual",
-                ),
+                name=NSFW_CATEGORY_LABELS.string("sexual"),
                 value="sexual",
             ),
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "Self Harm Instructions",
-                    key="cogs.nsfw.meta.categories.self_harm_instructions",
-                ),
+                name=NSFW_CATEGORY_LABELS.string("self_harm_instructions"),
                 value="self_harm_instructions",
             ),
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "Self Harm Intent",
-                    key="cogs.nsfw.meta.categories.self_harm_intent",
-                ),
+                name=NSFW_CATEGORY_LABELS.string("self_harm_intent"),
                 value="self_harm_intent",
             ),
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "Self Harm",
-                    key="cogs.nsfw.meta.categories.self_harm",
-                ),
+                name=NSFW_CATEGORY_LABELS.string("self_harm"),
                 value="self_harm",
             ),
         ]
@@ -180,10 +143,7 @@ class NSFWCog(commands.Cog):
 
     @nsfw_group.command(
         name="remove_category",
-        description=app_commands.locale_str(
-            "Remove a category from NSFW detection.",
-            key="cogs.nsfw.meta.remove_category.description",
-        ),
+        description=NSFW_META.string("remove_category", "description"),
     )
     @app_commands.autocomplete(category=category_manager.autocomplete)
     async def remove_category(self, interaction: Interaction, category: str):
@@ -197,10 +157,7 @@ class NSFWCog(commands.Cog):
 
     @nsfw_group.command(
         name="view_categories",
-        description=app_commands.locale_str(
-            "View NSFW detection categories.",
-            key="cogs.nsfw.meta.view_categories.description",
-        ),
+        description=NSFW_META.string("view_categories", "description"),
     )
     async def view_categories(self, interaction: Interaction):
         gid = interaction.guild.id
@@ -218,16 +175,10 @@ class NSFWCog(commands.Cog):
 
     @nsfw_group.command(
         name="set_threshold",
-        description=app_commands.locale_str(
-            "Set the threshold for NSFW detection confidence.",
-            key="cogs.nsfw.meta.set_threshold.description",
-        ),
+        description=NSFW_META.string("set_threshold", "description"),
     )
     @app_commands.describe(
-        threshold=app_commands.locale_str(
-            "Confidence threshold (0.0 to 1.0)",
-            key="cogs.nsfw.meta.set_threshold.params.threshold",
-        )
+        threshold=NSFW_META.child("set_threshold", "params").string("threshold")
     )
     async def set_threshold(self, interaction: Interaction, threshold: float):
         guild_id = interaction.guild.id
@@ -249,10 +200,7 @@ class NSFWCog(commands.Cog):
 
     @nsfw_group.command(
         name="view_threshold",
-        description=app_commands.locale_str(
-            "View the current NSFW detection threshold.",
-            key="cogs.nsfw.meta.view_threshold.description",
-        ),
+        description=NSFW_META.string("view_threshold", "description"),
     )
     async def view_threshold(self, interaction: Interaction):
         gid = interaction.guild.id

--- a/cogs/scam_detection.py
+++ b/cogs/scam_detection.py
@@ -17,6 +17,7 @@ from discord.ext import tasks
 from modules.utils.url_utils import extract_urls, unshorten_url, update_tld_list
 from modules.worker_queue import WorkerQueue
 from modules.core.moderator_bot import ModeratorBot
+from modules.i18n.strings import locale_string
 
 load_dotenv()
 GOOGLE_API_KEY = os.getenv('GOOGLE_API_KEY')
@@ -200,26 +201,17 @@ class ScamDetectionCog(commands.Cog):
 
     scam_group = app_commands.Group(
         name="scam",
-        description=app_commands.locale_str(
-            "Scam-detection configuration and pattern management.",
-            key="cogs.scam_detection.meta.group_description",
-        ),
+        description=locale_string("cogs.scam_detection.meta.group_description"),
         guild_only=True,
         default_permissions=discord.Permissions(manage_messages=True),
     )
 
     @scam_group.command(
         name="exclude_channel_add",
-        description=app_commands.locale_str(
-            "Exclude a channel from scam detection.",
-            key="cogs.scam_detection.meta.exclude_channel_add.description",
-        ),
+        description=locale_string("cogs.scam_detection.meta.exclude_channel_add.description"),
     )
     @app_commands.describe(
-        channel=app_commands.locale_str(
-            "The channel to exclude",
-            key="cogs.scam_detection.meta.exclude_channel_add.channel",
-        )
+        channel=locale_string("cogs.scam_detection.meta.exclude_channel_add.channel")
     )
     async def exclude_channel_add(self, interaction: Interaction, channel: discord.TextChannel):
         gid = interaction.guild.id
@@ -241,16 +233,10 @@ class ScamDetectionCog(commands.Cog):
 
     @scam_group.command(
         name="exclude_channel_remove",
-        description=app_commands.locale_str(
-            "Remove a channel from the exclusion list.",
-            key="cogs.scam_detection.meta.exclude_channel_remove.description",
-        ),
+        description=locale_string("cogs.scam_detection.meta.exclude_channel_remove.description"),
     )
     @app_commands.describe(
-        channel=app_commands.locale_str(
-            "The channel to remove from exclusion",
-            key="cogs.scam_detection.meta.exclude_channel_remove.channel",
-        )
+        channel=locale_string("cogs.scam_detection.meta.exclude_channel_remove.channel")
     )
     async def exclude_channel_remove(self, interaction: Interaction, channel: discord.TextChannel):
         gid = interaction.guild.id
@@ -272,10 +258,7 @@ class ScamDetectionCog(commands.Cog):
 
     @scam_group.command(
         name="exclude_channel_list",
-        description=app_commands.locale_str(
-            "List all excluded channels.",
-            key="cogs.scam_detection.meta.exclude_channel_list.description",
-        ),
+        description=locale_string("cogs.scam_detection.meta.exclude_channel_list.description"),
     )
     async def exclude_channel_list(self, interaction: Interaction):
         gid = interaction.guild.id
@@ -296,38 +279,23 @@ class ScamDetectionCog(commands.Cog):
         )
     @scam_group.command(
         name="check_links",
-        description=app_commands.locale_str(
-            "Toggle or view link checking.",
-            key="cogs.scam_detection.meta.check_links.description",
-        ),
+        description=locale_string("cogs.scam_detection.meta.check_links.description"),
     )
     @app_commands.describe(
-        action=app_commands.locale_str(
-            "enable | disable | status",
-            key="cogs.scam_detection.meta.check_links.action_description",
-        )
+        action=locale_string("cogs.scam_detection.meta.check_links.action_description")
     )
     @app_commands.choices(
         action=[
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "enable",
-                    key="cogs.scam_detection.meta.check_links.choices.enable",
-                ),
+                name=locale_string("cogs.scam_detection.meta.check_links.choices.enable"),
                 value="enable",
             ),
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "disable",
-                    key="cogs.scam_detection.meta.check_links.choices.disable",
-                ),
+                name=locale_string("cogs.scam_detection.meta.check_links.choices.disable"),
                 value="disable",
             ),
             app_commands.Choice(
-                name=app_commands.locale_str(
-                    "status",
-                    key="cogs.scam_detection.meta.check_links.choices.status",
-                ),
+                name=locale_string("cogs.scam_detection.meta.check_links.choices.status"),
                 value="status",
             ),
         ]
@@ -358,20 +326,11 @@ class ScamDetectionCog(commands.Cog):
 
     @scam_group.command(
         name="add_action",
-        description=app_commands.locale_str(
-            "Add an action to the scam punishment list.",
-            key="cogs.scam_detection.meta.add_action.description",
-        ),
+        description=locale_string("cogs.scam_detection.meta.add_action.description"),
     )
     @app_commands.describe(
-        action=app_commands.locale_str(
-            "Action to perform",
-            key="cogs.scam_detection.meta.add_action.action",
-        ),
-        duration=app_commands.locale_str(
-            "Only required for timeout (e.g. 10m, 1h, 3d)",
-            key="cogs.scam_detection.meta.add_action.duration",
-        ),
+        action=locale_string("cogs.scam_detection.meta.add_action.action"),
+        duration=locale_string("cogs.scam_detection.meta.add_action.duration"),
     )
     @app_commands.choices(action=action_choices())
     async def scam_add_action(
@@ -402,16 +361,10 @@ class ScamDetectionCog(commands.Cog):
 
     @scam_group.command(
         name="remove_action",
-        description=app_commands.locale_str(
-            "Remove an action from the scam punishment list.",
-            key="cogs.scam_detection.meta.remove_action.description",
-        ),
+        description=locale_string("cogs.scam_detection.meta.remove_action.description"),
     )
     @app_commands.describe(
-        action=app_commands.locale_str(
-            "Exact action string to remove (e.g. timeout:1d, delete)",
-            key="cogs.scam_detection.meta.remove_action.action",
-        )
+        action=locale_string("cogs.scam_detection.meta.remove_action.action")
     )
     @app_commands.autocomplete(action=manager.autocomplete)
     async def scam_remove_action(self, interaction: Interaction, action: str):
@@ -421,10 +374,7 @@ class ScamDetectionCog(commands.Cog):
 
     @scam_group.command(
         name="view",
-        description=app_commands.locale_str(
-            "View current scam settings.",
-            key="cogs.scam_detection.meta.view.description",
-        ),
+        description=locale_string("cogs.scam_detection.meta.view.description"),
     )
     async def settings_view(self, interaction: Interaction):
         gid = interaction.guild.id

--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -9,6 +9,7 @@ from modules.utils.localization import LocalizedError
 import traceback
 from modules.variables.TimeString import TimeString
 from modules.core.moderator_bot import ModeratorBot
+from modules.i18n.strings import locale_string
 
 MAX_CHARS = 1900  # Leave buffer for formatting
 CHUNK_SEPARATOR = "\n"
@@ -100,20 +101,14 @@ class Settings(commands.Cog):
 
     settings_group = app_commands.Group(
         name="settings",
-        description=app_commands.locale_str(
-            "Manage server settings.",
-            key="cogs.settings.meta.group_description",
-        ),
+        description=locale_string("cogs.settings.meta.group_description"),
         guild_only=True,
         default_permissions=discord.Permissions(manage_guild=True),
     )
 
     @settings_group.command(
         name="help",
-        description=app_commands.locale_str(
-            "Get help on settings.",
-            key="cogs.settings.meta.help.description",
-        ),
+        description=locale_string("cogs.settings.meta.help.description"),
     )
     async def help_settings(self, interaction: Interaction):
         """Get help on settings."""
@@ -151,10 +146,7 @@ class Settings(commands.Cog):
 
     @settings_group.command(
         name="reset",
-        description=app_commands.locale_str(
-            "Wipe all settings and start with defaults. This can't be undone",
-            key="cogs.settings.meta.reset.description",
-        ),
+        description=locale_string("cogs.settings.meta.reset.description"),
     )
     async def reset(self, interaction: Interaction):
         """Reset server settings."""
@@ -168,10 +160,7 @@ class Settings(commands.Cog):
 
     @settings_group.command(
         name="set",
-        description=app_commands.locale_str(
-            "Set a server setting.",
-            key="cogs.settings.meta.set.description",
-        ),
+        description=locale_string("cogs.settings.meta.set.description"),
     )
     @app_commands.autocomplete(value=value_autocomplete, name=name_autocomplete)
     async def set_setting(
@@ -292,16 +281,10 @@ class Settings(commands.Cog):
 
     @app_commands.command(
         name="help",
-        description=app_commands.locale_str(
-            "Get help on a specific command group.",
-            key="cogs.settings.meta.help.description",
-        ),
+        description=locale_string("cogs.settings.meta.help.description"),
     )
     @app_commands.describe(
-        command=app_commands.locale_str(
-            "Optional: command group to get help with",
-            key="cogs.settings.meta.help.options.command",
-        )
+        command=locale_string("cogs.settings.meta.help.options.command")
     )
     @app_commands.default_permissions(moderate_members=True)
     async def help(self, interaction: Interaction, command: Optional[str] = None):
@@ -515,10 +498,7 @@ class Settings(commands.Cog):
 
     @settings_group.command(
         name="get",
-        description=app_commands.locale_str(
-            "Get the current value of a server setting.",
-            key="cogs.settings.meta.get.description",
-        ),
+        description=locale_string("cogs.settings.meta.get.description"),
     )
     @app_commands.autocomplete(name=name_autocomplete)
     async def get_setting(self, interaction: Interaction, name: str):
@@ -589,10 +569,7 @@ class Settings(commands.Cog):
 
     @settings_group.command(
         name="remove",
-        description=app_commands.locale_str(
-            "Remove a server setting or an item from a list-type setting.",
-            key="cogs.settings.meta.remove.description",
-        ),
+        description=locale_string("cogs.settings.meta.remove.description"),
     )
     @app_commands.autocomplete(name=name_autocomplete)
     async def remove_setting(

--- a/cogs/strikes.py
+++ b/cogs/strikes.py
@@ -12,6 +12,7 @@ from modules.utils.discord_utils import safe_get_user
 from modules.utils.strike import validate_action
 from modules.variables.TimeString import TimeString
 from modules.core.moderator_bot import ModeratorBot
+from modules.i18n.strings import locale_string
 
 async def autocomplete_strike_action(interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:
     settings = await mysql.get_settings(interaction.guild.id, "strike-actions") or {}
@@ -32,10 +33,7 @@ class StrikesCog(commands.Cog):
 
     strike_group = app_commands.Group(
         name="strikes",
-        description=app_commands.locale_str(
-            "Strike management commands.",
-            key="cogs.strikes.meta.group_description",
-        ),
+        description=locale_string("cogs.strikes.meta.group_description"),
         default_permissions=discord.Permissions(moderate_members=True),
         guild_only=True
     )
@@ -43,24 +41,12 @@ class StrikesCog(commands.Cog):
     #strike
     @app_commands.command(
         name="strike",
-        description=app_commands.locale_str(
-            "Strike a specific user.",
-            key="cogs.strikes.meta.strike.description",
-        ),
+        description=locale_string("cogs.strikes.meta.strike.description"),
     )
     @app_commands.describe(
-        user=app_commands.locale_str(
-            "The member to strike.",
-            key="cogs.strikes.meta.strike.params.user",
-        ),
-        reason=app_commands.locale_str(
-            "The reason for the strike.",
-            key="cogs.strikes.meta.strike.params.reason",
-        ),
-        expiry=app_commands.locale_str(
-            "Optional expiry duration (e.g., 30d, 2w).",
-            key="cogs.strikes.meta.strike.params.expiry",
-        ),
+        user=locale_string("cogs.strikes.meta.strike.params.user"),
+        reason=locale_string("cogs.strikes.meta.strike.params.reason"),
+        expiry=locale_string("cogs.strikes.meta.strike.params.expiry"),
     )
     @app_commands.default_permissions(moderate_members=True)
     @app_commands.guild_only()
@@ -91,10 +77,7 @@ class StrikesCog(commands.Cog):
 
     @strike_group.command(
         name="get",
-        description=app_commands.locale_str(
-            "Get strikes of a specific user.",
-            key="cogs.strikes.meta.get.description",
-        ),
+        description=locale_string("cogs.strikes.meta.get.description"),
     )
     @app_commands.guild_only()
     async def get_strikes(self, interaction: Interaction, user: Member):
@@ -161,16 +144,10 @@ class StrikesCog(commands.Cog):
     # Clear strikes
     @strike_group.command(
         name="clear",
-        description=app_commands.locale_str(
-            "Clear all strikes of a specific user.",
-            key="cogs.strikes.meta.clear.description",
-        ),
+        description=locale_string("cogs.strikes.meta.clear.description"),
     )
     @app_commands.describe(
-        user=app_commands.locale_str(
-            "The user whose strikes will be cleared.",
-            key="cogs.strikes.meta.clear.params.user",
-        ),
+        user=locale_string("cogs.strikes.meta.clear.params.user"),
     )
     @app_commands.default_permissions(moderate_members=True)
     @app_commands.guild_only()
@@ -205,24 +182,12 @@ class StrikesCog(commands.Cog):
 
     @strike_group.command(
         name="add_action",
-        description=app_commands.locale_str(
-            "Add an additional action for a strike level.",
-            key="cogs.strikes.meta.add_action.description",
-        ),
+        description=locale_string("cogs.strikes.meta.add_action.description"),
     )
     @app_commands.describe(
-        number_of_strikes=app_commands.locale_str(
-            "Number of strikes required to trigger the action.",
-            key="cogs.strikes.meta.add_action.params.number_of_strikes",
-        ),
-        action=app_commands.locale_str(
-            "Action to add.",
-            key="cogs.strikes.meta.add_action.params.action",
-        ),
-        duration=app_commands.locale_str(
-            "Duration (only for timeout, e.g., 1h, 30m). Leave empty otherwise.",
-            key="cogs.strikes.meta.add_action.params.duration",
-        ),
+        number_of_strikes=locale_string("cogs.strikes.meta.add_action.params.number_of_strikes"),
+        action=locale_string("cogs.strikes.meta.add_action.params.action"),
+        duration=locale_string("cogs.strikes.meta.add_action.params.duration"),
     )
     @app_commands.choices(action=action_choices(exclude=("delete", "strike")))
     async def add_strike_action(
@@ -270,20 +235,11 @@ class StrikesCog(commands.Cog):
 
     @strike_group.command(
         name="remove_action",
-        description=app_commands.locale_str(
-            "Remove an action from a strike level.",
-            key="cogs.strikes.meta.remove_action.description",
-        ),
+        description=locale_string("cogs.strikes.meta.remove_action.description"),
     )
     @app_commands.describe(
-        number_of_strikes=app_commands.locale_str(
-            "Number of strikes associated with the action.",
-            key="cogs.strikes.meta.remove_action.params.number_of_strikes",
-        ),
-        action=app_commands.locale_str(
-            "Exact action string to remove.",
-            key="cogs.strikes.meta.remove_action.params.action",
-        ),
+        number_of_strikes=locale_string("cogs.strikes.meta.remove_action.params.number_of_strikes"),
+        action=locale_string("cogs.strikes.meta.remove_action.params.action"),
     )
     @app_commands.autocomplete(action=autocomplete_strike_action)
     async def remove_strike_action(self, interaction: Interaction, number_of_strikes: int, action: str):
@@ -315,10 +271,7 @@ class StrikesCog(commands.Cog):
 
     @strike_group.command(
         name="view_actions",
-        description=app_commands.locale_str(
-            "View all configured strike actions.",
-            key="cogs.strikes.meta.view_actions.description",
-        ),
+        description=locale_string("cogs.strikes.meta.view_actions.description"),
     )
     async def view_strike_actions(self, interaction: Interaction):
         """View all configured strike actions."""
@@ -343,20 +296,11 @@ class StrikesCog(commands.Cog):
     # Warn channel or optionally user
     @app_commands.command(
         name="intimidate",
-        description=app_commands.locale_str(
-            "Intimidate the channel, or a specific user.",
-            key="cogs.strikes.meta.intimidate.description",
-        ),
+        description=locale_string("cogs.strikes.meta.intimidate.description"),
     )
     @app_commands.describe(
-        user=app_commands.locale_str(
-            "User to intimidate. Leave empty to address the whole channel.",
-            key="cogs.strikes.meta.intimidate.params.user",
-        ),
-        channel=app_commands.locale_str(
-            "Send the warning in the channel instead of a direct message.",
-            key="cogs.strikes.meta.intimidate.params.channel",
-        )
+        user=locale_string("cogs.strikes.meta.intimidate.params.user"),
+        channel=locale_string("cogs.strikes.meta.intimidate.params.channel")
     )
     @app_commands.default_permissions(moderate_members=True)
     @app_commands.guild_only()

--- a/modules/i18n/strings.py
+++ b/modules/i18n/strings.py
@@ -1,0 +1,121 @@
+"""Utilities for referencing locale strings consistently across the codebase."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Iterable
+
+from discord import app_commands
+
+__all__ = [
+    "LocaleNamespace",
+    "locale_key",
+    "locale_value",
+    "locale_string",
+    "locale_namespace",
+]
+
+
+def _iter_segments(parts: Iterable[str]) -> Iterable[str]:
+    for part in parts:
+        if not part:
+            continue
+        for segment in part.split('.'):
+            segment = segment.strip()
+            if segment:
+                yield segment
+
+
+def locale_key(*parts: str) -> str:
+    """Return a normalised locale key composed from *parts*."""
+
+    return '.'.join(_iter_segments(parts))
+
+
+def _deep_merge(base: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    for key, value in incoming.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+@lru_cache(maxsize=None)
+def _load_locale(locale: str) -> dict[str, Any]:
+    """Load the bundled fallback locale for resolving command metadata."""
+
+    root = Path(__file__).resolve().parents[2] / "locales" / locale
+    if not root.exists():
+        return {}
+
+    data: dict[str, Any] = {}
+    for path in sorted(root.rglob("*.json")):
+        try:
+            with path.open("r", encoding="utf-8-sig") as handle:
+                payload = json.load(handle)
+        except FileNotFoundError:
+            continue
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Failed to parse locale file {path}: {exc}") from exc
+        if isinstance(payload, dict):
+            data = _deep_merge(data, payload)
+    return data
+
+
+def locale_value(key: str, *, locale: str = "en") -> Any:
+    """Return the fallback value stored in the bundled *locale* for *key*."""
+
+    cursor: Any = _load_locale(locale)
+    for segment in locale_key(key).split('.'):
+        if not segment:
+            continue
+        if isinstance(cursor, dict) and segment in cursor:
+            cursor = cursor[segment]
+        else:
+            raise KeyError(key)
+    return cursor
+
+
+def locale_string(*parts: str, fallback_locale: str = "en", **extras: Any) -> app_commands.locale_str:
+    """Create an :func:`discord.app_commands.locale_str` with automatic fallback."""
+
+    key = extras.pop("key", None)
+    if key is None:
+        key = locale_key(*parts)
+    fallback = extras.pop("default", None)
+    if fallback is None:
+        try:
+            value = locale_value(key, locale=fallback_locale)
+        except KeyError:
+            value = key
+    else:
+        value = fallback
+    return app_commands.locale_str(value, key=key, **extras)
+
+
+@dataclass(frozen=True)
+class LocaleNamespace:
+    """Helper for building locale keys with a shared prefix."""
+
+    parts: tuple[str, ...]
+
+    def key(self, *parts: str) -> str:
+        return locale_key(*self.parts, *parts)
+
+    def value(self, *parts: str, fallback_locale: str = "en") -> Any:
+        key = self.key(*parts)
+        return locale_value(key, locale=fallback_locale)
+
+    def string(self, *parts: str, fallback_locale: str = "en", **extras: Any) -> app_commands.locale_str:
+        return locale_string(*self.parts, *parts, fallback_locale=fallback_locale, **extras)
+
+    def child(self, *parts: str) -> "LocaleNamespace":
+        return LocaleNamespace(self.parts + tuple(_iter_segments(parts)))
+
+
+def locale_namespace(*parts: str) -> LocaleNamespace:
+    return LocaleNamespace(tuple(_iter_segments(parts)))

--- a/modules/utils/actions.py
+++ b/modules/utils/actions.py
@@ -1,31 +1,39 @@
+from __future__ import annotations
+
 from typing import Iterable, Optional, Union
+
 from discord import app_commands
 
+from modules.i18n.strings import locale_namespace
 
-def _choice_label(fallback: str, value: str) -> app_commands.locale_str:
-    return app_commands.locale_str(
-        fallback,
-        key=f"modules.utils.actions.choices.{value}",
-    )
+CHOICE_LABELS = locale_namespace("modules", "utils", "actions", "choices")
+
+
+def _choice_label(value: str, *, fallback: str | None = None) -> app_commands.locale_str:
+    extras: dict[str, str] = {}
+    if fallback is not None:
+        extras["default"] = fallback
+    return CHOICE_LABELS.string(value, **extras)
 
 
 ACTIONS = [
-    (_choice_label("Strike", "strike"), "strike"),
-    (_choice_label("Kick", "kick"), "kick"),
-    (_choice_label("Ban", "ban"), "ban"),
-    (_choice_label("Timeout", "timeout"), "timeout"),
-    (_choice_label("Delete Message", "delete"), "delete"),
-    (_choice_label("Give Role", "give_role"), "give_role"),
-    (_choice_label("Remove Role", "take_role"), "take_role"),
-    (_choice_label("Warn User", "warn"), "warn"),
-    (_choice_label("Broadcast Message", "broadcast"), "broadcast"),
+    (_choice_label("strike"), "strike"),
+    (_choice_label("kick"), "kick"),
+    (_choice_label("ban"), "ban"),
+    (_choice_label("timeout"), "timeout"),
+    (_choice_label("delete"), "delete"),
+    (_choice_label("give_role"), "give_role"),
+    (_choice_label("take_role"), "take_role"),
+    (_choice_label("warn"), "warn"),
+    (_choice_label("broadcast"), "broadcast"),
 ]
 
 VALID_ACTION_VALUES = [a[1] for a in ACTIONS]
 
+
 def action_choices(
     exclude: Iterable[str] = (),
-    include: Optional[Union[Iterable[str], Iterable[tuple[str, str]]]] = None
+    include: Optional[Union[Iterable[str], Iterable[tuple[str, str]]]] = None,
 ) -> list[app_commands.Choice[str]]:
     exclude_set = set(exclude)
 
@@ -34,10 +42,10 @@ def action_choices(
     if include:
         for item in include:
             if isinstance(item, str):
-                base.append((_choice_label(item.capitalize(), item), item))
+                base.append((_choice_label(item, fallback=item.capitalize()), item))
             else:
                 label, value = item
-                base.append((_choice_label(label, value), value))
+                base.append((_choice_label(value, fallback=label), value))
 
     seen = set()
     final = []


### PR DESCRIPTION
## Summary
- add a central modules/i18n/strings.py helper that loads bundled fallbacks and builds locale_str references
- migrate slash command definitions to use locale_string/namespace helpers instead of repeating English fallbacks
- refresh i18n tests to cover the new helper behaviour and translator logging expectations

## Testing
- pytest tests/test_moderator_bot_locale.py

------