### PR TITLE
Add missing locale warnings with suggestions

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,48 @@
+# Internationalisation (i18n) Guide
+
+Moderator Bot ships with a file-based localisation system powered by JSON
+resources stored in the `locales/` directory. Each locale has its own folder
+(e.g. `locales/en/`) that mirrors the internal structure of the bot's modules.
+
+## Locale files
+
+Locale files are nested JSON objects. Keys are separated by dots (`.`) when they
+are accessed in code. For example, given the following excerpt from
+`locales/uk-UA/modules.moderation.json`:
+
+```json
+{
+  "modules": {
+    "moderation": {
+      "strike": {
+        "disciplinary": {
+          "no_action": "Ніяких дій не було вжито.",
+          "bulk_delete": "{deleted}/{total} повідомлень видалено одним пакетом."
+        }
+      }
+    }
+  }
+}
+```
+
+You can retrieve the `bulk_delete` message via the key
+`modules.moderation.strike.disciplinary.bulk_delete`.
+
+## Adding new strings
+
+1. Identify the locale you want to update (e.g. `en` for English).
+2. Create or edit the JSON file corresponding to the relevant feature.
+3. Follow the existing nesting convention so the dotted key path matches the
+   JSON hierarchy.
+
+Strings can include placeholder values using Python's `str.format` syntax. For
+instance, the `{deleted}` and `{total}` placeholders in the example above are
+replaced at runtime.
+
+## Fallback behaviour
+
+If a string is missing from a requested locale, Moderator Bot automatically
+falls back to the configured default and fallback locales. When this happens the
+bot now logs a warning indicating which locale was missing and which fallback
+was used. The log also includes a "Did you mean …?" suggestion when another
+locale closely matches the requested code.

--- a/modules/i18n/locales.py
+++ b/modules/i18n/locales.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from threading import Lock
 from typing import Any
 
+from .logging_utils import format_missing_locale_message
+
 logger = logging.getLogger(__name__)
 
 class LocaleRepository:
@@ -138,7 +140,10 @@ class LocaleRepository:
 
     def _log_missing_locale(self, locale: str) -> None:
         level = logging.WARNING if self._should_warn_for_locale(locale) else logging.DEBUG
-        logger.log(level, "Requested locale %s missing from cache", locale)
+        with self._lock:
+            available = tuple(self._cache.keys())
+        message = format_missing_locale_message(locale, self._fallback_locale, available)
+        logger.log(level, message)
 
     def _resolve_key(self, locale: str, data: dict[str, Any] | None, key: str) -> Any:
         if data is None:

--- a/modules/i18n/logging_utils.py
+++ b/modules/i18n/logging_utils.py
@@ -1,0 +1,49 @@
+"""Helpers for emitting consistent i18n logging messages."""
+
+from __future__ import annotations
+
+from difflib import get_close_matches
+from typing import Iterable
+
+
+def suggest_locale(target: str, available: Iterable[str]) -> str | None:
+    """Return the closest matching locale code for *target*.
+
+    Parameters
+    ----------
+    target:
+        The locale code that was requested by the caller.
+    available:
+        An iterable of available locale identifiers.
+
+    Returns
+    -------
+    Optional[str]
+        The closest matching locale code, if a sufficiently similar candidate
+        exists. The similarity threshold mirrors :func:`difflib.get_close_matches`.
+    """
+
+    matches = get_close_matches(target, list(available), n=1, cutoff=0.6)
+    return matches[0] if matches else None
+
+
+def format_missing_locale_message(
+    requested: str,
+    fallback: str,
+    available: Iterable[str],
+) -> str:
+    """Return a human-readable warning for a missing locale.
+
+    The message includes the configured fallback locale and, when possible, a
+    "did you mean" suggestion for the closest known locale identifier.
+    """
+
+    suggestion = suggest_locale(requested, available)
+    suggestion_hint = f" Did you mean '{suggestion}'?" if suggestion else ""
+    return (
+        "Requested locale '%s' missing from cache; using fallback '%s'.%s"
+        % (requested, fallback, suggestion_hint)
+    )
+
+
+__all__ = ["format_missing_locale_message", "suggest_locale"]


### PR DESCRIPTION
## Summary
- add logging utilities to format missing locale warnings and surface closest matches
- update the locale repository to warn when falling back and include a "Did you mean" suggestion
- document how i18n keys map to JSON files and describe the new fallback behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df602bd768832da5fa1926ee88d64b